### PR TITLE
Parse Error Risk in JS Sources

### DIFF
--- a/src/adapter/bootstrap/entity/message/close.js
+++ b/src/adapter/bootstrap/entity/message/close.js
@@ -9,4 +9,4 @@ $(window).load(function(){
         
         $(this).prepend('<button type="button" class="close" data-dismiss="alert">×</button>')
     })
-})
+});

--- a/src/adapter/bootstrap/entity/nav/bar-ie.js
+++ b/src/adapter/bootstrap/entity/nav/bar-ie.js
@@ -1,3 +1,3 @@
 $(window).load(function(){
     Blocks.IE.fixRadiusGradient('nav.bar')
-})
+});

--- a/src/adapter/bootstrap/entity/nav/bar.js
+++ b/src/adapter/bootstrap/entity/nav/bar.js
@@ -63,6 +63,6 @@
     $(window).load(reflowNavbarOverflows);
     $(window).resize(reflowNavbarOverflows)
     
-})()
+})();
 
 

--- a/src/core/adapter/base/_namespaces-ie.js
+++ b/src/core/adapter/base/_namespaces-ie.js
@@ -1,4 +1,4 @@
 if(typeof Blocks == 'undefined')
-    var Blocks = {}
+    var Blocks = {};
 
-Blocks.IE = {}
+Blocks.IE = {};

--- a/src/core/adapter/base/_namespaces.js
+++ b/src/core/adapter/base/_namespaces.js
@@ -1,2 +1,2 @@
 if(typeof blocks == 'undefined')
-    var Blocks = {}
+    var Blocks = {};


### PR DESCRIPTION
Some of the JS source files do not end in a semi-colon. While Javascript is loose about when semi-colons are needed, at least one of these (the message one) actually required it. As such, I've added semi-colons to all JS sources that thus exist to avoid such a risk. 

Moving forward, it should be a requirement that all files end in a semi-colon (this is my own mistake on these). The minifiers will strip these out if they're not needed, so it's safety without cost.
