### PR TITLE
Fix U+FEFF in nav/list.js

### DIFF
--- a/src/adapter/bootstrap/entity/nav/list.js
+++ b/src/adapter/bootstrap/entity/nav/list.js
@@ -1,4 +1,4 @@
-﻿$(function () {
+$(function () {
 
     $('.list.accordion').on('click', 'a', function (event) {
         event.preventDefault();


### PR DESCRIPTION
The `U+FEFF` character can cause some minifiers to choke so removing it from `nav/list.js` functionality committed by @loganfranken.
