### PR TITLE
Add //!requires Precompiler Primitive

### DIFF
--- a/lib/Build/Adapter/Bootstrap.rb
+++ b/lib/Build/Adapter/Bootstrap.rb
@@ -22,6 +22,15 @@ module WebBlocks
         def preprocess
           
           preprocess_submodule :bootstrap
+          preprocess_css
+          
+        end
+        
+        def preprocess_css
+          
+          log.task "Adapter: Bootstrap", "Resolving SASS dependenties in Bootstrap adapter" do
+            resolve_sass_dependencies src_adapter_dir :bootstrap 
+          end
           
         end
         

--- a/lib/Build/Core/Adapter.rb
+++ b/lib/Build/Core/Adapter.rb
@@ -15,6 +15,20 @@ module WebBlocks
         include ::WebBlocks::Path::Source
         include ::WebBlocks::Build::Module
         
+        def preprocess
+          
+          preprocess_css
+          
+        end
+        
+        def preprocess_css
+          
+          log.task "Core: Adapter", "Resolving SASS dependenties in core adapter" do
+            resolve_sass_dependencies src_core_adapter_dir 
+          end
+          
+        end
+        
         def link
           
           link_css

--- a/lib/Build/Core/Definitions.rb
+++ b/lib/Build/Core/Definitions.rb
@@ -14,6 +14,20 @@ module WebBlocks
         include ::WebBlocks::Path::Source
         include ::WebBlocks::Build::Module
         
+        def preprocess
+          
+          preprocess_css
+          
+        end
+        
+        def preprocess_css
+          
+          log.task "Core: Definitions", "Resolving SASS dependenties in core definitions" do
+            resolve_sass_dependencies src_core_definitions_dir
+          end
+          
+        end
+        
         def link
           
           link_css

--- a/lib/Build/Core/Extensions.rb
+++ b/lib/Build/Core/Extensions.rb
@@ -14,6 +14,8 @@ module WebBlocks
         include ::WebBlocks::Path::Source
         include ::WebBlocks::Build::Module
         
+        # TODO: support // @requires in extensions
+        
         def link
           
           link_css

--- a/lib/Build/Module.rb
+++ b/lib/Build/Module.rb
@@ -53,23 +53,33 @@ module WebBlocks
         
         modules.each do |dir|
           
-          dir = ::WebBlocks::Path.to base_dir, dir
+          subpath = ''
           
-          if File.exists? "#{dir}.scss"
-            files << "#{dir}.scss"
-          end
+          dir.split('/').each do |segment|
+            
+            subpath << '/' unless subpath.length == 0
+            subpath << segment
+            path = ::WebBlocks::Path.to base_dir, subpath
+            
+            if File.exists? "#{path}.scss"
+              files << "#{path}.scss"
+            end
 
-          if File.exists? "#{File.dirname(dir)}/_#{File.basename(dir)}.scss"
-            files << "#{File.dirname(dir)}/_#{File.basename(dir)}.scss"
-          end
+            if File.exists? "#{File.dirname(path)}/_#{File.basename(path)}.scss"
+              files << "#{File.dirname(path)}/_#{File.basename(path)}.scss"
+            end
 
-          if File.exists? "#{dir}-ie.scss"
-            files << "#{dir}-ie.scss"
-          end
+            if File.exists? "#{dir}-ie.scss"
+              files << "#{dir}-ie.scss"
+            end
 
-          if File.exists? "#{File.dirname(dir)}/_#{File.basename(dir)}-ie.scss"
-            files << "#{File.dirname(dir)}/_#{File.basename(dir)}-ie.scss"
+            if File.exists? "#{File.dirname(path)}/_#{File.basename(path)}-ie.scss"
+              files << "#{File.dirname(path)}/_#{File.basename(path)}-ie.scss"
+            end
+            
           end
+          
+          dir = ::WebBlocks::Path.to base_dir, dir
           
           get_files(dir, 'scss').sort.each do |file|
             files << file unless file.match /\/_+variables.scss$/
@@ -77,9 +87,12 @@ module WebBlocks
           
         end
         
+        traversed = []
         if block_given?
           files.each do |file|
-            yield file
+            next if traversed.include? file
+            yield file 
+            traversed << file
           end
         end
         

--- a/lib/Build/Module.rb
+++ b/lib/Build/Module.rb
@@ -179,6 +179,8 @@ module WebBlocks
           config[:src][:modules] = modules
         
         end
+        
+        log.warning "Dependencies did not stabilize because of loop"
           
       end
       

--- a/lib/Build/Module.rb
+++ b/lib/Build/Module.rb
@@ -171,7 +171,11 @@ module WebBlocks
             modules << initial_module unless already_set
 
           end
+          
+          # exit if we've stabilized dependencies
+          return if config[:src][:modules].to_s == modules.to_s
 
+          # otherwise set config modules and loop again to try to stabilize
           config[:src][:modules] = modules
         
         end

--- a/lib/Build/Module.rb
+++ b/lib/Build/Module.rb
@@ -95,9 +95,9 @@ module WebBlocks
           
           File.open file, "r" do |file|
             
-            lines = file.grep /^\/\/\s*@requires\s/
+            lines = file.grep /^\/\/\s*\!requires\s/
             lines.each do |line|
-              line.gsub! /^\/\/\s*@requires\s*/, ''
+              line.gsub! /^\/\/\s*\!requires\s*/, ''
               dependencies << line.split(/\s/)
             end
             

--- a/lib/Build/Module.rb
+++ b/lib/Build/Module.rb
@@ -39,6 +39,54 @@ module WebBlocks
         
       end
       
+      def sass_libs_for base_dir
+        
+        files = []
+        
+        get_files(base_dir, 'scss').each do |file|
+          files << file if file.match /\/_+require.scss$/ or file.match /\/_+variables.scss$/
+        end
+
+        get_files(base_dir, 'scss', false).each do |file|
+          files << file unless file.match /\/_+require.scss$/ or file.match /\/_+variables.scss$/
+        end
+        
+        modules.each do |dir|
+          
+          dir = ::WebBlocks::Path.to base_dir, dir
+          
+          if File.exists? "#{dir}.scss"
+            files << "#{dir}.scss"
+          end
+
+          if File.exists? "#{File.dirname(dir)}/_#{File.basename(dir)}.scss"
+            files << "#{File.dirname(dir)}/_#{File.basename(dir)}.scss"
+          end
+
+          if File.exists? "#{dir}-ie.scss"
+            files << "#{dir}-ie.scss"
+          end
+
+          if File.exists? "#{File.dirname(dir)}/_#{File.basename(dir)}-ie.scss"
+            files << "#{File.dirname(dir)}/_#{File.basename(dir)}-ie.scss"
+          end
+          
+          get_files(dir, 'scss').sort.each do |file|
+            files << file unless file.match /\/_+variables.scss$/
+          end
+          
+        end
+        
+        if block_given?
+          files.each do |file|
+            yield file
+          end
+        end
+        
+        files
+        
+      end
+      
       def link_sass_lib file
         
         if file.match /\/_+variables.scss$/
@@ -59,47 +107,9 @@ module WebBlocks
       end
     
       def link_sass_libs_for base_dir
-
-        get_files(base_dir, 'scss').each do |file|
-          if file.match /\/_+require.scss$/ or file.match /\/_+variables.scss$/
-            link_sass_lib file
-          end
-        end
-
-        get_files(base_dir, 'scss', false).each do |file|
-          unless file.match /\/_+require.scss$/ or file.match /\/_+variables.scss$/ # as already included
-            link_sass_lib file
-          end
-        end
         
-        modules.each do |dir|
-          
-          dir = ::WebBlocks::Path.to base_dir, dir
-          
-          if File.exists? "#{dir}.scss"
-            link_sass_lib "#{dir}.scss"
-          end
-
-          if File.exists? "#{File.dirname(dir)}/_#{File.basename(dir)}.scss"
-            link_sass_lib "#{File.dirname(dir)}/_#{File.basename(dir)}.scss"
-          end
-
-          if File.exists? "#{dir}-ie.scss"
-            link_sass_lib "#{dir}-ie.scss"
-          end
-
-          if File.exists? "#{File.dirname(dir)}/_#{File.basename(dir)}-ie.scss"
-            link_sass_lib "#{File.dirname(dir)}/_#{File.basename(dir)}-ie.scss"
-          end
-          
-          get_files(dir, 'scss').sort.each do |file|
-
-            next if file.match /\/_+variables.scss$/
-
-            link_sass_lib file
-
-          end
-          
+        sass_libs_for base_dir do |file|
+          link_sass_lib file
         end
 
       end


### PR DESCRIPTION
This pull request adds the functionality discussed in #140.

Dependencies in a SASS file may be specified as:

``` css
//!requires MODULE_NAME
```

If a file is to be included and it includes a primitive of this form, then `MODULE_NAME` will be added to the set of modules to include.
