### PR TITLE
Fix Module Inclusion Bug

### DIFF
--- a/lib/Build/Adapter/Bootstrap.rb
+++ b/lib/Build/Adapter/Bootstrap.rb
@@ -4,6 +4,7 @@ require_relative '../../Path'
 require_relative '../Submodule'
 require_relative '../Utilities'
 require_relative '../Module'
+require_relative '../../Logger'
 
 module WebBlocks
   
@@ -13,6 +14,7 @@ module WebBlocks
       
       class Bootstrap
         
+        include ::WebBlocks::Logger
         include ::WebBlocks::Path::Source
         include ::WebBlocks::Path::Temporary_Build
         include ::WebBlocks::Build::Submodule

--- a/lib/Build/Core/Adapter.rb
+++ b/lib/Build/Core/Adapter.rb
@@ -3,6 +3,7 @@ require 'extensions/kernel'
 require_relative '../../Path'
 require_relative '../Module'
 require_relative '../Utilities'
+require_relative '../../Logger'
 
 module WebBlocks
   
@@ -12,6 +13,7 @@ module WebBlocks
       
       class Adapter
         
+        include ::WebBlocks::Logger
         include ::WebBlocks::Path::Source
         include ::WebBlocks::Build::Module
         

--- a/lib/Build/Core/Definitions.rb
+++ b/lib/Build/Core/Definitions.rb
@@ -2,6 +2,7 @@ require 'rubygems'
 require 'extensions/kernel'
 require_relative '../../Path'
 require_relative '../Module'
+require_relative '../../Logger'
 
 module WebBlocks
   
@@ -11,6 +12,7 @@ module WebBlocks
       
       class Definitions
         
+        include ::WebBlocks::Logger
         include ::WebBlocks::Path::Source
         include ::WebBlocks::Build::Module
         

--- a/lib/Build/Core/Extensions.rb
+++ b/lib/Build/Core/Extensions.rb
@@ -2,6 +2,7 @@ require 'rubygems'
 require 'extensions/kernel'
 require_relative '../../Path'
 require_relative '../Module'
+require_relative '../../Logger'
 
 module WebBlocks
   
@@ -11,6 +12,7 @@ module WebBlocks
       
       class Extensions
         
+        include ::WebBlocks::Logger
         include ::WebBlocks::Path::Source
         include ::WebBlocks::Build::Module
         

--- a/lib/Build/Package/Efx.rb
+++ b/lib/Build/Package/Efx.rb
@@ -3,6 +3,7 @@ require 'extensions/kernel'
 require_relative '../../Path'
 require_relative '../Submodule'
 require_relative '../Utilities'
+require_relative '../../Logger'
 
 module WebBlocks
   
@@ -12,6 +13,7 @@ module WebBlocks
       
       class Efx
         
+        include ::WebBlocks::Logger
         include ::WebBlocks::Path::Temporary_Build
         include ::WebBlocks::Build::Submodule
         include ::WebBlocks::Build::Utilities

--- a/lib/Build/Package/Jquery.rb
+++ b/lib/Build/Package/Jquery.rb
@@ -3,6 +3,7 @@ require 'extensions/kernel'
 require_relative '../../Path'
 require_relative '../Submodule'
 require_relative '../Utilities'
+require_relative '../../Logger'
 
 module WebBlocks
   
@@ -12,6 +13,7 @@ module WebBlocks
       
       class Jquery
         
+        include ::WebBlocks::Logger
         include ::WebBlocks::Path::Temporary_Build
         include ::WebBlocks::Build::Submodule
         include ::WebBlocks::Build::Utilities

--- a/lib/Build/Package/Modernizr.rb
+++ b/lib/Build/Package/Modernizr.rb
@@ -3,6 +3,7 @@ require 'extensions/kernel'
 require_relative '../../Path'
 require_relative '../Submodule'
 require_relative '../Utilities'
+require_relative '../../Logger'
 
 module WebBlocks
   
@@ -12,6 +13,7 @@ module WebBlocks
       
       class Modernizr
         
+        include ::WebBlocks::Logger
         include ::WebBlocks::Path::Temporary_Build
         include ::WebBlocks::Build::Submodule
         include ::WebBlocks::Build::Utilities

--- a/lib/Build/Package/Respond.rb
+++ b/lib/Build/Package/Respond.rb
@@ -3,6 +3,7 @@ require 'extensions/kernel'
 require_relative '../../Path'
 require_relative '../Submodule'
 require_relative '../Utilities'
+require_relative '../../Logger'
 
 module WebBlocks
   
@@ -12,6 +13,7 @@ module WebBlocks
       
       class Respond
         
+        include ::WebBlocks::Logger
         include ::WebBlocks::Path::Temporary_Build
         include ::WebBlocks::Build::Submodule
         include ::WebBlocks::Build::Utilities

--- a/lib/Build/Package/Selectivizr.rb
+++ b/lib/Build/Package/Selectivizr.rb
@@ -3,6 +3,7 @@ require 'extensions/kernel'
 require_relative '../../Path'
 require_relative '../Submodule'
 require_relative '../Utilities'
+require_relative '../../Logger'
 
 module WebBlocks
   
@@ -12,6 +13,7 @@ module WebBlocks
       
       class Selectivizr
         
+        include ::WebBlocks::Logger
         include ::WebBlocks::Path::Temporary_Build
         include ::WebBlocks::Build::Submodule
         include ::WebBlocks::Build::Utilities

--- a/lib/Build/WebBlocks.rb
+++ b/lib/Build/WebBlocks.rb
@@ -4,6 +4,7 @@ require 'systemu'
 require 'fileutils'
 require_relative '../Path'
 require_relative 'Utilities'
+require_relative '../Logger'
 
 module WebBlocks
   
@@ -11,6 +12,7 @@ module WebBlocks
       
     class WebBlocks
       
+      include ::WebBlocks::Logger
       include ::WebBlocks::Path::Source
       include ::WebBlocks::Path::Temporary_Build
       include ::WebBlocks::Path::Build
@@ -356,6 +358,8 @@ module WebBlocks
       end
       
       module Append
+        
+        extend ::WebBlocks::Config
 
         def self.compressed_css_file src, dst
           status, stdout, stderr = systemu "#{config[:exec][:uglifycss]} \"#{src}\" > \"#{dst}\""


### PR DESCRIPTION
Some of the module handlers assume the WebBlocks::Rake DSL. This is not reasonable for things like unit tests which will hook into the build stack in other ways and should be tweaked accordingly.
