### PR TITLE
First child heading does not get top margin [#173]

### DIFF
--- a/src/adapter/bootstrap/base/type/_font.scss
+++ b/src/adapter/bootstrap/base/type/_font.scss
@@ -1,1 +1,9 @@
-@mixin -base-type-font { }
+@mixin -base-type-font {
+    
+    h1, h2, h3, h4, h5, h6 {
+        &:first-child {
+            margin-top: 0;
+        }
+    }
+    
+}


### PR DESCRIPTION
This adds a fix to the Bootstrap adapter so that, if a heading element is the first child, it does not get a top margin.
