### PR TITLE
Package/lettering [#189]

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "package/efx"]
 	path = package/efx
 	url = https://github.com/ebollens/efx.git
+[submodule "package/lettering"]
+	path = package/lettering
+	url = https://github.com/davatron5000/Lettering.js.git

--- a/demo/extend/type.html
+++ b/demo/extend/type.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html>
+    
+    <head>
+        
+        <title>Extend/Base/Type</title>
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+        
+        <link rel="stylesheet" href="../../build/css/blocks.css">
+        <script type="text/javascript" src="../../build/js/blocks.js"></script>
+        
+        <!--[if lte IE 9]>
+        <link rel="stylesheet" href="../../build/css/blocks-ie.css">
+        <script type="text/javascript" src="../../build/js/blocks-ie.js"></script>
+        <![endif]-->
+        
+    </head>
+    
+    <body class="container">
+        
+        <h1>Extend/Base/Type</h1>
+
+        <p>This is an extended library for Base/Type.</p>
+
+        <h2>Extend/Base/Type/Split</h2>
+        
+        <p>The Extend/Base/Type/Split library makes it easy to apply 
+            typographical effects such as kerning, tracking and leading via the
+            "lettering" package (Lettering.js). It creates a span around each 
+            character if using <code>.text-split-chars</code>, word if 
+            using <code>.text-split-words</code> and line if 
+            using <code>.text-split-lines</code>.</p>
+        <p>For example, if character splitting is used around "abc", then "b" 
+            can be styled with <code>.char2 { .. }</code> or, if "ab cd ef" is
+            used with word splitting, then "ef" may be styled with 
+            <code>.word3 { .. }</code>.
+        </p>
+        
+        <p>This library requires the "lettering" package:</p>
+        
+        <p><code>WebBlocks.config[:build][:packages] << :lettering</code></p>
+
+        <h4>Split Characters (.text-split-chars)</h4>
+        
+        <p class="text-split-chars">Each char is assigned a class .charX</p>
+
+        <h4>Split Words (.text-split-words)</h4>
+        
+        <p class="text-split-words">Each word is assigned a class .wordX</p>
+
+        <h4>Split Words (.text-split-words)</h4>
+        
+        <p class="text-split-lines">Each line is <br>assigned a <br>class .lineX</p>
+        
+        <h4>Variations</h4>
+        
+        <p class="text-split-chars text-split-words">When using .text-split-chars.text-split-words, each word is assigned a class <code>.wordX</code> and each character is assigned a class .charY</p>
+        
+        <p class="text-split-chars text-split-lines">When using .text-split-chars.text-split-lines, <br>each line is assigned a class <code>.lineX</code> <br>and each character is assigned a class .charY</p>
+        
+        <p class="text-split-words text-split-lines">When using .text-split-words.text-split-lines, <br>each line is assigned a class <code>.lineX</code> <br>and each word is assigned a class .wordY</p>
+        
+        <p class="text-split-chars text-split-words text-split-lines">When using .text-split-chars.text-split-words.text-split-lines, <br>each line is assigned a class <code>.lineX</code>, <br>each word is assigned a <code>.wordY</code>, <br>and each character is assigned a class .charZ</p>
+        
+        <script type="text/javascript">
+            
+        </script>
+        
+    </body>
+    
+</html>

--- a/lib/Build/Package/Lettering.rb
+++ b/lib/Build/Package/Lettering.rb
@@ -1,0 +1,62 @@
+require 'rubygems'
+require 'extensions/kernel'
+require_relative '../../Path'
+require_relative '../Submodule'
+require_relative '../Utilities'
+require_relative '../../Logger'
+
+module WebBlocks
+  
+  module Build
+    
+    module Package
+      
+      class Lettering
+        
+        include ::WebBlocks::Logger
+        include ::WebBlocks::Path::Temporary_Build
+        include ::WebBlocks::Build::Submodule
+        include ::WebBlocks::Build::Utilities
+        
+        def preprocess
+          
+          preprocess_js
+          
+        end
+        
+        def preprocess_js
+          
+          preprocess_submodule :lettering
+          add_module 'extend/base/type/split'
+          
+        end
+        
+        def assemble
+          
+          assemble_js
+          
+        end
+        
+        def assemble_js
+          
+          log.task "Package: Lettering.js", "Copying jquery.lettering.js to JS build file" do
+            file = "#{package_dir :lettering}/jquery.lettering.js"
+            log.debug "#{tmp_js_build_file.gsub /^#{root_dir}\//, ''} <<- #{file.gsub /^#{root_dir}\//, ''}"
+            append_file file, tmp_js_build_file
+          end
+          
+        end
+        
+        def reset_package
+          
+          reset_submodule :lettering
+          
+        end
+        
+      end
+      
+    end
+    
+  end
+  
+end

--- a/lib/Config.rb
+++ b/lib/Config.rb
@@ -179,6 +179,10 @@ module WebBlocks
     :dir      => 'jquery'
   }
   
+  @config[:package][:lettering] = {
+    :dir      => 'lettering'
+  }
+  
   @config[:package][:modernizr] = {
     :dir      => 'modernizr'
   }

--- a/src/core/adapter/extend/base/type/split.js
+++ b/src/core/adapter/extend/base/type/split.js
@@ -1,0 +1,34 @@
+$(document).ready(function(){
+    
+    var linesClass = 'text-split-lines',
+        wordsClass = 'text-split-words',
+        charsClass = 'text-split-chars'
+
+    $('.'+linesClass).each(function(){
+
+        var $this = $(this)
+
+        $this.lettering('lines')
+
+        if($this.hasClass(wordsClass))
+            $this.removeClass(wordsClass).children('span').addClass(wordsClass)
+
+        if($this.hasClass(charsClass))
+            $this.removeClass(charsClass).children('span').addClass(charsClass)
+
+    })
+
+    $('.'+wordsClass).each(function(){
+
+        var $this = $(this)
+
+        $this.lettering('words')
+
+        if($this.hasClass(charsClass))
+            $this.removeClass(charsClass).children('span').addClass(charsClass)
+
+    })
+
+    $('.'+charsClass).lettering()
+
+});

--- a/src/core/definitions/extend/base/type/_split.scss
+++ b/src/core/definitions/extend/base/type/_split.scss
@@ -1,0 +1,11 @@
+.text-split-chars {
+    
+}
+
+.text-split-words {
+    
+}
+
+.text-split-lines {
+    
+}


### PR DESCRIPTION
This pull request adds a new package `lettering`.

In addition to this new package, it introduces the namespace `extend/base/type/split` with the following:
- `text-split-chars`
- `text-split-words`
- `text-split-lines`

Basically, if chars are split, then each char is wrapped in a span with `charX` as a class name where `X` denotes the number of that character across the set in the directly containing element. Same with `wordX` for word splitting and `lineX` for line splitting. If these are used in combination, you'll be able to target something like the second character of the third word word of the fourth line as: `.line4 > .word3 > .char2 { .. }`.

This feature makes it possible to do easy leading, kerning and tracking.

It uses http://letteringjs.com/ as a submodule.
