### PR TITLE
Base/Structure/Grid Collapse Support [fixes #174]

### DIFF
--- a/demo/base/structure.html
+++ b/demo/base/structure.html
@@ -98,6 +98,105 @@
                     .panel-12
                 </div>
             </div>
+            
+            <h3>Grid System Collapse Controls</h3>
+            
+            <p>The default behavior for a <code>row</code> is that it collapses
+            at <code>$breakpoint-small</code>. However, this is not always
+            the intended behavior.</p>
+            
+            <h4>No Collapse</h4>
+            
+            <p>If the grid should never collapse, use 
+            <code>.row.no-collapse</code>:</p>
+            
+            <div class="row no-collapse">
+                <div class="panel-6">
+                    .panel-6
+                </div>
+                <div class="panel-6">
+                    .panel-6
+                </div>
+            </div>
+            
+            <h4>Collapse within No Collapse</h4>
+            
+            <p>A non-collapsing row can have rows within it that still do 
+            collapse:</p>
+            
+            <div class="row no-collapse">
+                <div class="panel-6 primary">
+                    .row.no-collapse .panel-6
+                    <div class="row secondary">
+                        <div class="panel-6">.row .panel-6</div>
+                        <div class="panel-6">.row .panel-6</div>
+                    </div>
+                </div>
+                <div class="panel-6 primary">
+                    .row.no-collapse .panel-6
+                    <div class="row secondary">
+                        <div class="panel-6">.row .panel-6</div>
+                        <div class="panel-6">.row .panel-6</div>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="row no-collapse">
+                <div class="panel-6 primary">
+                    .row.no-collapse .panel-6
+                    <div class="row small-collapse secondary">
+                        <div class="panel-6">.row.small-collapse .panel-6</div>
+                        <div class="panel-6">.row.small-collapse .panel-6</div>
+                    </div>
+                </div>
+                <div class="panel-6 primary">
+                    .row.no-collapse .panel-6
+                    <div class="row small-collapse secondary">
+                        <div class="panel-6">.row.small-collapse .panel-6</div>
+                        <div class="panel-6">.row.small-collapse .panel-6</div>
+                    </div>
+                </div>
+            </div>
+            
+            <h3>No Collapse within Collapse</h3>
+            
+            <p>Similarly, a collapsing row can have non-collapsing rows within 
+            it:</p>
+            
+            <div class="row">
+                <div class="panel-6 primary">
+                    .row .panel-6
+                    <div class="row no-collapse secondary">
+                        <div class="panel-6">.row.no-collapse .panel-6</div>
+                        <div class="panel-6">.row.no-collapse .panel-6</div>
+                    </div>
+                </div>
+                <div class="panel-6 primary">
+                    .row .panel-6
+                    <div class="row no-collapse secondary">
+                        <div class="panel-6">.row.no-collapse .panel-6</div>
+                        <div class="panel-6">.row.no-collapse .panel-6</div>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="row small-collapse">
+                <div class="panel-6 primary">
+                    .row.small-collapse .panel-6
+                    <div class="row no-collapse secondary">
+                        <div class="panel-6">.row.no-collapse .panel-6</div>
+                        <div class="panel-6">.row.no-collapse .panel-6</div>
+                    </div>
+                </div>
+                <div class="panel-6 primary">
+                    .row.small-collapse .panel-6
+                    <div class="row no-collapse secondary">
+                        <div class="panel-6">.row.no-collapse .panel-6</div>
+                        <div class="panel-6">.row.no-collapse .panel-6</div>
+                    </div>
+                </div>
+            </div>
+            
         </div>
         
     </body>

--- a/demo/base/structure.html
+++ b/demo/base/structure.html
@@ -112,10 +112,10 @@
             
             <div class="row no-collapse">
                 <div class="panel-6">
-                    .panel-6
+                    .row.no-collapse .panel-6
                 </div>
                 <div class="panel-6">
-                    .panel-6
+                    .row.no-collapse .panel-6
                 </div>
             </div>
             
@@ -127,10 +127,10 @@
             
             <div class="row small-collapse">
                 <div class="panel-6">
-                    .panel-6
+                    .row.small-collapse .panel-6
                 </div>
                 <div class="panel-6">
-                    .panel-6
+                    .row.small-collapse .panel-6
                 </div>
             </div>
             
@@ -141,10 +141,24 @@
             
             <div class="row medium-collapse">
                 <div class="panel-6">
-                    .panel-6
+                    .row.medium-collapse .panel-6
                 </div>
                 <div class="panel-6">
-                    .panel-6
+                    .row.medium-collapse .panel-6
+                </div>
+            </div>
+            
+            <h4>Large Collapse</h4>
+            
+            <p>If the grid should collapse at <code>$breakpoint-large</code>, 
+            use <code>.row.large-collapse</code>:</p>
+            
+            <div class="row large-collapse">
+                <div class="panel-6">
+                    .row.large-collapse .panel-6
+                </div>
+                <div class="panel-6">
+                    .row.large-collapse .panel-6
                 </div>
             </div>
             
@@ -204,6 +218,23 @@
                 </div>
             </div>
             
+            <div class="row no-collapse">
+                <div class="panel-6">
+                    .row.no-collapse .panel-6
+                    <div class="row large-collapse">
+                        <div class="panel-6">.row.large-collapse .panel-6</div>
+                        <div class="panel-6">.row.large-collapse .panel-6</div>
+                    </div>
+                </div>
+                <div class="panel-6">
+                    .row.no-collapse .panel-6
+                    <div class="row large-collapse">
+                        <div class="panel-6">.row.large-collapse .panel-6</div>
+                        <div class="panel-6">.row.large-collapse .panel-6</div>
+                    </div>
+                </div>
+            </div>
+            
             <h3>No Collapse within Collapse</h3>
             
             <p>Similarly, a collapsing row can have non-collapsing rows within 
@@ -253,6 +284,23 @@
                 </div>
                 <div class="panel-6">
                     .row.medium-collapse .panel-6
+                    <div class="row no-collapse">
+                        <div class="panel-6">.row.no-collapse .panel-6</div>
+                        <div class="panel-6">.row.no-collapse .panel-6</div>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="row large-collapse">
+                <div class="panel-6">
+                    .row.large-collapse .panel-6
+                    <div class="row no-collapse">
+                        <div class="panel-6">.row.no-collapse .panel-6</div>
+                        <div class="panel-6">.row.no-collapse .panel-6</div>
+                    </div>
+                </div>
+                <div class="panel-6">
+                    .row.large-collapse .panel-6
                     <div class="row no-collapse">
                         <div class="panel-6">.row.no-collapse .panel-6</div>
                         <div class="panel-6">.row.no-collapse .panel-6</div>

--- a/demo/base/structure.html
+++ b/demo/base/structure.html
@@ -119,7 +119,35 @@
                 </div>
             </div>
             
-            <h4>Small Collapse</h4>
+            <h4>Collapse for xxsmall</h4>
+            
+            <p>If the grid should collapse at <code>$breakpoint-xxsmall</code>, 
+            use <code>.row.xxsmall-collapse</code>:</p>
+            
+            <div class="row xxsmall-collapse">
+                <div class="panel-6">
+                    .row.xxsmall-collapse .panel-6
+                </div>
+                <div class="panel-6">
+                    .row.xxsmall-collapse .panel-6
+                </div>
+            </div>
+            
+            <h4>Collapse for xsmall</h4>
+            
+            <p>If the grid should collapse at <code>$breakpoint-xsmall</code>, 
+            use <code>.row.xsmall-collapse</code>:</p>
+            
+            <div class="row xsmall-collapse">
+                <div class="panel-6">
+                    .row.xsmall-collapse .panel-6
+                </div>
+                <div class="panel-6">
+                    .row.xsmall-collapse .panel-6
+                </div>
+            </div>
+            
+            <h4>Collapse for small</h4>
             
             <p>If the grid should collapse at <code>$breakpoint-small</code>, 
             the use of <code>.row.small-collapse</code> is optional (this is 
@@ -134,7 +162,21 @@
                 </div>
             </div>
             
-            <h4>Medium Collapse</h4>
+            <h4>Collapse for medium-small</h4>
+            
+            <p>If the grid should collapse at <code>$breakpoint-medium-small</code>, 
+            use <code>.row.medium-small-collapse</code>:</p>
+            
+            <div class="row medium-small-collapse">
+                <div class="panel-6">
+                    .row.medium-small-collapse .panel-6
+                </div>
+                <div class="panel-6">
+                    .row.medium-small-collapse .panel-6
+                </div>
+            </div>
+            
+            <h4>Collapse for medium</h4>
             
             <p>If the grid should collapse at <code>$breakpoint-medium</code>, 
             use <code>.row.medium-collapse</code>:</p>
@@ -145,6 +187,20 @@
                 </div>
                 <div class="panel-6">
                     .row.medium-collapse .panel-6
+                </div>
+            </div>
+            
+            <h4>Collapse for medium-large</h4>
+            
+            <p>If the grid should collapse at <code>$breakpoint-medium-large</code>, 
+            use <code>.row.medium-large-collapse</code>:</p>
+            
+            <div class="row medium-large-collapse">
+                <div class="panel-6">
+                    .row.medium-large-collapse .panel-6
+                </div>
+                <div class="panel-6">
+                    .row.medium-large-collapse .panel-6
                 </div>
             </div>
             
@@ -187,6 +243,40 @@
             <div class="row no-collapse">
                 <div class="panel-6">
                     .row.no-collapse .panel-6
+                    <div class="row xxsmall-collapse">
+                        <div class="panel-6">.row.xxsmall-collapse .panel-6</div>
+                        <div class="panel-6">.row.xxsmall-collapse .panel-6</div>
+                    </div>
+                </div>
+                <div class="panel-6">
+                    .row.no-collapse .panel-6
+                    <div class="row xxsmall-collapse">
+                        <div class="panel-6">.row.xxsmall-collapse .panel-6</div>
+                        <div class="panel-6">.row.xxsmall-collapse .panel-6</div>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="row no-collapse">
+                <div class="panel-6">
+                    .row.no-collapse .panel-6
+                    <div class="row xsmall-collapse">
+                        <div class="panel-6">.row.xsmall-collapse .panel-6</div>
+                        <div class="panel-6">.row.xsmall-collapse .panel-6</div>
+                    </div>
+                </div>
+                <div class="panel-6">
+                    .row.no-collapse .panel-6
+                    <div class="row xsmall-collapse">
+                        <div class="panel-6">.row.xsmall-collapse .panel-6</div>
+                        <div class="panel-6">.row.xsmall-collapse .panel-6</div>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="row no-collapse">
+                <div class="panel-6">
+                    .row.no-collapse .panel-6
                     <div class="row small-collapse">
                         <div class="panel-6">.row.small-collapse .panel-6</div>
                         <div class="panel-6">.row.small-collapse .panel-6</div>
@@ -204,6 +294,23 @@
             <div class="row no-collapse">
                 <div class="panel-6">
                     .row.no-collapse .panel-6
+                    <div class="row medium-small-collapse">
+                        <div class="panel-6">.row.medium-small-collapse .panel-6</div>
+                        <div class="panel-6">.row.medium-small-collapse .panel-6</div>
+                    </div>
+                </div>
+                <div class="panel-6">
+                    .row.no-collapse .panel-6
+                    <div class="row medium-small-collapse">
+                        <div class="panel-6">.row.medium-small-collapse .panel-6</div>
+                        <div class="panel-6">.row.medium-small-collapse .panel-6</div>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="row no-collapse">
+                <div class="panel-6">
+                    .row.no-collapse .panel-6
                     <div class="row medium-collapse">
                         <div class="panel-6">.row.medium-collapse .panel-6</div>
                         <div class="panel-6">.row.medium-collapse .panel-6</div>
@@ -214,6 +321,23 @@
                     <div class="row medium-collapse">
                         <div class="panel-6">.row.medium-collapse .panel-6</div>
                         <div class="panel-6">.row.medium-collapse .panel-6</div>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="row no-collapse">
+                <div class="panel-6">
+                    .row.no-collapse .panel-6
+                    <div class="row medium-large-collapse">
+                        <div class="panel-6">.row.medium-large-collapse .panel-6</div>
+                        <div class="panel-6">.row.medium-large-collapse .panel-6</div>
+                    </div>
+                </div>
+                <div class="panel-6">
+                    .row.no-collapse .panel-6
+                    <div class="row medium-large-collapse">
+                        <div class="panel-6">.row.medium-large-collapse .panel-6</div>
+                        <div class="panel-6">.row.medium-large-collapse .panel-6</div>
                     </div>
                 </div>
             </div>
@@ -257,6 +381,40 @@
                 </div>
             </div>
             
+            <div class="row xxsmall-collapse">
+                <div class="panel-6">
+                    .row.xxsmall-collapse .panel-6
+                    <div class="row no-collapse">
+                        <div class="panel-6">.row.no-collapse .panel-6</div>
+                        <div class="panel-6">.row.no-collapse .panel-6</div>
+                    </div>
+                </div>
+                <div class="panel-6">
+                    .row.xxsmall-collapse .panel-6
+                    <div class="row no-collapse">
+                        <div class="panel-6">.row.no-collapse .panel-6</div>
+                        <div class="panel-6">.row.no-collapse .panel-6</div>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="row xsmall-collapse">
+                <div class="panel-6">
+                    .row.xsmall-collapse .panel-6
+                    <div class="row no-collapse">
+                        <div class="panel-6">.row.no-collapse .panel-6</div>
+                        <div class="panel-6">.row.no-collapse .panel-6</div>
+                    </div>
+                </div>
+                <div class="panel-6">
+                    .row.xsmall-collapse .panel-6
+                    <div class="row no-collapse">
+                        <div class="panel-6">.row.no-collapse .panel-6</div>
+                        <div class="panel-6">.row.no-collapse .panel-6</div>
+                    </div>
+                </div>
+            </div>
+            
             <div class="row small-collapse">
                 <div class="panel-6">
                     .row.small-collapse .panel-6
@@ -274,6 +432,23 @@
                 </div>
             </div>
             
+            <div class="row medium-small-collapse">
+                <div class="panel-6">
+                    .row.medium-small-collapse .panel-6
+                    <div class="row no-collapse">
+                        <div class="panel-6">.row.no-collapse .panel-6</div>
+                        <div class="panel-6">.row.no-collapse .panel-6</div>
+                    </div>
+                </div>
+                <div class="panel-6">
+                    .row.medium-small-collapse .panel-6
+                    <div class="row no-collapse">
+                        <div class="panel-6">.row.no-collapse .panel-6</div>
+                        <div class="panel-6">.row.no-collapse .panel-6</div>
+                    </div>
+                </div>
+            </div>
+            
             <div class="row medium-collapse">
                 <div class="panel-6">
                     .row.medium-collapse .panel-6
@@ -284,6 +459,23 @@
                 </div>
                 <div class="panel-6">
                     .row.medium-collapse .panel-6
+                    <div class="row no-collapse">
+                        <div class="panel-6">.row.no-collapse .panel-6</div>
+                        <div class="panel-6">.row.no-collapse .panel-6</div>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="row medium-large-collapse">
+                <div class="panel-6">
+                    .row.medium-large-collapse .panel-6
+                    <div class="row no-collapse">
+                        <div class="panel-6">.row.no-collapse .panel-6</div>
+                        <div class="panel-6">.row.no-collapse .panel-6</div>
+                    </div>
+                </div>
+                <div class="panel-6">
+                    .row.medium-large-collapse .panel-6
                     <div class="row no-collapse">
                         <div class="panel-6">.row.no-collapse .panel-6</div>
                         <div class="panel-6">.row.no-collapse .panel-6</div>

--- a/demo/base/structure.html
+++ b/demo/base/structure.html
@@ -94,7 +94,7 @@
                 </div>
             </div>
             <div class="row">
-                <div class="panel-12 important">
+                <div class="panel-12">
                     .panel-12
                 </div>
             </div>
@@ -119,22 +119,51 @@
                 </div>
             </div>
             
+            <h4>Small Collapse</h4>
+            
+            <p>If the grid should collapse at <code>$breakpoint-small</code>, 
+            the use of <code>.row.small-collapse</code> is optional (this is 
+            the default collapse behavior):</p>
+            
+            <div class="row small-collapse">
+                <div class="panel-6">
+                    .panel-6
+                </div>
+                <div class="panel-6">
+                    .panel-6
+                </div>
+            </div>
+            
+            <h4>Medium Collapse</h4>
+            
+            <p>If the grid should collapse at <code>$breakpoint-medium</code>, 
+            use <code>.row.medium-collapse</code>:</p>
+            
+            <div class="row medium-collapse">
+                <div class="panel-6">
+                    .panel-6
+                </div>
+                <div class="panel-6">
+                    .panel-6
+                </div>
+            </div>
+            
             <h4>Collapse within No Collapse</h4>
             
             <p>A non-collapsing row can have rows within it that still do 
             collapse:</p>
             
             <div class="row no-collapse">
-                <div class="panel-6 primary">
+                <div class="panel-6">
                     .row.no-collapse .panel-6
-                    <div class="row secondary">
+                    <div class="row">
                         <div class="panel-6">.row .panel-6</div>
                         <div class="panel-6">.row .panel-6</div>
                     </div>
                 </div>
-                <div class="panel-6 primary">
+                <div class="panel-6">
                     .row.no-collapse .panel-6
-                    <div class="row secondary">
+                    <div class="row">
                         <div class="panel-6">.row .panel-6</div>
                         <div class="panel-6">.row .panel-6</div>
                     </div>
@@ -142,18 +171,35 @@
             </div>
             
             <div class="row no-collapse">
-                <div class="panel-6 primary">
+                <div class="panel-6">
                     .row.no-collapse .panel-6
-                    <div class="row small-collapse secondary">
+                    <div class="row small-collapse">
                         <div class="panel-6">.row.small-collapse .panel-6</div>
                         <div class="panel-6">.row.small-collapse .panel-6</div>
                     </div>
                 </div>
-                <div class="panel-6 primary">
+                <div class="panel-6">
                     .row.no-collapse .panel-6
-                    <div class="row small-collapse secondary">
+                    <div class="row small-collapse">
                         <div class="panel-6">.row.small-collapse .panel-6</div>
                         <div class="panel-6">.row.small-collapse .panel-6</div>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="row no-collapse">
+                <div class="panel-6">
+                    .row.no-collapse .panel-6
+                    <div class="row medium-collapse">
+                        <div class="panel-6">.row.medium-collapse .panel-6</div>
+                        <div class="panel-6">.row.medium-collapse .panel-6</div>
+                    </div>
+                </div>
+                <div class="panel-6">
+                    .row.no-collapse .panel-6
+                    <div class="row medium-collapse">
+                        <div class="panel-6">.row.medium-collapse .panel-6</div>
+                        <div class="panel-6">.row.medium-collapse .panel-6</div>
                     </div>
                 </div>
             </div>
@@ -164,16 +210,16 @@
             it:</p>
             
             <div class="row">
-                <div class="panel-6 primary">
+                <div class="panel-6">
                     .row .panel-6
-                    <div class="row no-collapse secondary">
+                    <div class="row no-collapse">
                         <div class="panel-6">.row.no-collapse .panel-6</div>
                         <div class="panel-6">.row.no-collapse .panel-6</div>
                     </div>
                 </div>
-                <div class="panel-6 primary">
+                <div class="panel-6">
                     .row .panel-6
-                    <div class="row no-collapse secondary">
+                    <div class="row no-collapse">
                         <div class="panel-6">.row.no-collapse .panel-6</div>
                         <div class="panel-6">.row.no-collapse .panel-6</div>
                     </div>
@@ -181,16 +227,33 @@
             </div>
             
             <div class="row small-collapse">
-                <div class="panel-6 primary">
+                <div class="panel-6">
                     .row.small-collapse .panel-6
-                    <div class="row no-collapse secondary">
+                    <div class="row no-collapse">
                         <div class="panel-6">.row.no-collapse .panel-6</div>
                         <div class="panel-6">.row.no-collapse .panel-6</div>
                     </div>
                 </div>
-                <div class="panel-6 primary">
+                <div class="panel-6">
                     .row.small-collapse .panel-6
-                    <div class="row no-collapse secondary">
+                    <div class="row no-collapse">
+                        <div class="panel-6">.row.no-collapse .panel-6</div>
+                        <div class="panel-6">.row.no-collapse .panel-6</div>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="row medium-collapse">
+                <div class="panel-6">
+                    .row.medium-collapse .panel-6
+                    <div class="row no-collapse">
+                        <div class="panel-6">.row.no-collapse .panel-6</div>
+                        <div class="panel-6">.row.no-collapse .panel-6</div>
+                    </div>
+                </div>
+                <div class="panel-6">
+                    .row.medium-collapse .panel-6
+                    <div class="row no-collapse">
                         <div class="panel-6">.row.no-collapse .panel-6</div>
                         <div class="panel-6">.row.no-collapse .panel-6</div>
                     </div>
@@ -198,6 +261,22 @@
             </div>
             
         </div>
+        
+        <style>
+            .row {
+                margin-bottom: 1em;
+            }
+            .row .row {
+                margin-bottom: 0;
+            }
+            [class*="panel-"] {
+                background-color: #e4e4e4;
+            }
+            
+            [class*="panel-"] [class*="panel-"] { 
+                background-color: #ccc;
+            }
+        </style>
         
     </body>
     

--- a/src/core/adapter/base/_variables.scss
+++ b/src/core/adapter/base/_variables.scss
@@ -2,6 +2,10 @@
  * Breakpoints 
  */
 
-$breakpoint-small:     768px !default;     /* width-based */
-$breakpoint-medium:    960px !default;     /* width-based */
-$breakpoint-large:     1200px !default;    /* width-based */
+$breakpoint-xxsmall:        360px !default;         /* 360px is iPhone vertical */
+$breakpoint-xsmall:         480px !default;         /* 480px is iPhone horizontal */
+$breakpoint-small:          600px !default;
+$breakpoint-medium-small:   768px !default;         /* 768px is iPad horizontal */
+$breakpoint-medium:         960px !default;
+$breakpoint-medium-large:   1024px !default;        /* 1024px is iPad vertical */
+$breakpoint-large:          1200px !default;

--- a/src/core/adapter/base/structure/grid/_panel.scss
+++ b/src/core/adapter/base/structure/grid/_panel.scss
@@ -1,5 +1,8 @@
-﻿@mixin -base-structure-grid-panel {
+@mixin -base-structure-grid-panel {
     float: left;
+    &.float-right {
+        float: right;
+    }
     &:not(:first-child) {
         margin-left: $structure-panel-gutter;
     }

--- a/src/core/adapter/base/structure/grid/_panel_collapsed.scss
+++ b/src/core/adapter/base/structure/grid/_panel_collapsed.scss
@@ -1,3 +1,4 @@
 @mixin -base-structure-grid-panel-collapsed {
     width: 100%;
+    margin-left: 0;
 }

--- a/src/core/definitions/base/structure/_grid.scss
+++ b/src/core/definitions/base/structure/_grid.scss
@@ -51,7 +51,7 @@
  * Default and .small-collapse behavior collapses at $breakpoint-small 
  */
 
-.row.no-collapse .row,
+.row[class*="-collapse"] .row,
 .row {
     
     &.medium-collapse {  
@@ -69,6 +69,34 @@
         }
         
         @media screen and (min-width: $breakpoint-medium) {
+            @include -base-structure-grid-panels-generate;
+        }
+    
+    }
+}
+
+/**
+ * Default and .small-collapse behavior collapses at $breakpoint-small 
+ */
+
+.row[class*="-collapse"] .row,
+.row {
+    
+    &.large-collapse {  
+          
+        [class*="panel-"] {
+
+            @media screen and (min-width: $breakpoint-large) {
+                @include -base-structure-grid-panel;
+            }
+
+            @media screen and (max-width: $breakpoint-large - 1) {
+                @include -base-structure-grid-panel-collapsed;
+            }
+
+        }
+        
+        @media screen and (min-width: $breakpoint-large) {
             @include -base-structure-grid-panels-generate;
         }
     

--- a/src/core/definitions/base/structure/_grid.scss
+++ b/src/core/definitions/base/structure/_grid.scss
@@ -20,6 +20,62 @@
 }
 
 /**
+ * .xxsmall-collapse behavior collapses at $breakpoint-xsmall 
+ */
+
+.row[class*="-collapse"] .row,
+.row {
+    
+    &.xxsmall-collapse {  
+          
+        [class*="panel-"] {
+
+            @media screen and (min-width: $breakpoint-xxsmall+1) {
+                @include -base-structure-grid-panel;
+            }
+
+            @media screen and (max-width: $breakpoint-xxsmall) {
+                @include -base-structure-grid-panel-collapsed;
+            }
+
+        }
+        
+        @media screen and (min-width: $breakpoint-xxsmall+1) {
+            @include -base-structure-grid-panels-generate;
+        }
+    
+    }
+}
+
+/**
+ * .xsmall-collapse behavior collapses at $breakpoint-xsmall 
+ */
+
+.row[class*="-collapse"] .row,
+.row {
+    
+    &.xsmall-collapse {  
+          
+        [class*="panel-"] {
+
+            @media screen and (min-width: $breakpoint-xsmall+1) {
+                @include -base-structure-grid-panel;
+            }
+
+            @media screen and (max-width: $breakpoint-xsmall) {
+                @include -base-structure-grid-panel-collapsed;
+            }
+
+        }
+        
+        @media screen and (min-width: $breakpoint-xsmall+1) {
+            @include -base-structure-grid-panels-generate;
+        }
+    
+    }
+}
+
+/**
  * Default and .small-collapse behavior collapses at $breakpoint-small 
  */
 
@@ -48,7 +104,35 @@
 }
 
 /**
- * Default and .small-collapse behavior collapses at $breakpoint-small 
+ * .medium-small-collapse behavior collapses at $breakpoint-medium-small 
+ */
+
+.row[class*="-collapse"] .row,
+.row {
+    
+    &.medium-small-collapse {  
+          
+        [class*="panel-"] {
+
+            @media screen and (min-width: $breakpoint-medium-small+1) {
+                @include -base-structure-grid-panel;
+            }
+
+            @media screen and (max-width: $breakpoint-medium-small) {
+                @include -base-structure-grid-panel-collapsed;
+            }
+
+        }
+        
+        @media screen and (min-width: $breakpoint-medium-small+1) {
+            @include -base-structure-grid-panels-generate;
+        }
+    
+    }
+}
+
+/**
+ * .medium-collapse behavior collapses at $breakpoint-medium 
  */
 
 .row[class*="-collapse"] .row,
@@ -69,6 +153,34 @@
         }
         
         @media screen and (min-width: $breakpoint-medium+1) {
+            @include -base-structure-grid-panels-generate;
+        }
+    
+    }
+}
+
+/**
+ * .medium-large-collapse behavior collapses at $breakpoint-medium-large 
+ */
+
+.row[class*="-collapse"] .row,
+.row {
+    
+    &.medium-large-collapse {  
+          
+        [class*="panel-"] {
+
+            @media screen and (min-width: $breakpoint-medium-large+1) {
+                @include -base-structure-grid-panel;
+            }
+
+            @media screen and (max-width: $breakpoint-medium-large) {
+                @include -base-structure-grid-panel-collapsed;
+            }
+
+        }
+        
+        @media screen and (min-width: $breakpoint-medium-large+1) {
             @include -base-structure-grid-panels-generate;
         }
     

--- a/src/core/definitions/base/structure/_grid.scss
+++ b/src/core/definitions/base/structure/_grid.scss
@@ -2,25 +2,65 @@
     @include -base-structure-grid-row;
 }
 
-[class*="panel-"] {
+/**
+ * Widths are always available on panels for % width controls
+ */
+
+@mixin -base-structure-grid-panels-generate {
     
-    @media screen and (min-width: $breakpoint-small) {
-        @include -base-structure-grid-panel;
-    }
-    
-    @media screen and (max-width: $breakpoint-small - 1) {
-        @include -base-structure-grid-panel-collapsed;
+    $i: $structure-panels; @while $i > 0 {
+
+        .panel-#{$i} { 
+            @include -base-structure-grid-panel-fluid-span($i, $structure-panel-width, $structure-panel-gutter); 
+        }
+
+        $i: ($i - 1);
     }
     
 }
 
-$i: $structure-panels; @while $i > 0 {
+/**
+ * Default and .small-collapse behavior collapses at $breakpoint-small 
+ */
+
+.row.no-collapse .row,
+.row {
     
-    .panel-#{$i} { 
-        @media screen and (min-width: $breakpoint-small) {
-            @include -base-structure-grid-panel-fluid-span($i, $structure-panel-width, $structure-panel-gutter); 
+    &:not([class*="-collapse"]), &.small-collapse {  
+          
+        [class*="panel-"] {
+
+            @media screen and (min-width: $breakpoint-small) {
+                @include -base-structure-grid-panel;
+            }
+
+            @media screen and (max-width: $breakpoint-small - 1) {
+                @include -base-structure-grid-panel-collapsed;
+            }
+
         }
-    }
+        
+        @media screen and (min-width: $breakpoint-small) {
+                @include -base-structure-grid-panels-generate;
+                }
     
-    $i: ($i - 1);
+    }
+}
+
+/**
+ * .no-collapse behavior never collapses the row
+ */
+
+.row:not(.no-collapse) .row,
+.row {
+    
+    &.no-collapse {
+        
+        [class*="panel-"] {
+            @include -base-structure-grid-panel;
+        }
+        
+        @include -base-structure-grid-panels-generate;
+        
+    }
 }

--- a/src/core/definitions/base/structure/_grid.scss
+++ b/src/core/definitions/base/structure/_grid.scss
@@ -23,7 +23,7 @@
  * Default and .small-collapse behavior collapses at $breakpoint-small 
  */
 
-.row.no-collapse .row,
+.row[class*="-collapse"] .row,
 .row {
     
     &:not([class*="-collapse"]), &.small-collapse {  
@@ -41,8 +41,36 @@
         }
         
         @media screen and (min-width: $breakpoint-small) {
-                @include -base-structure-grid-panels-generate;
-                }
+            @include -base-structure-grid-panels-generate;
+        }
+    
+    }
+}
+
+/**
+ * Default and .small-collapse behavior collapses at $breakpoint-small 
+ */
+
+.row.no-collapse .row,
+.row {
+    
+    &.medium-collapse {  
+          
+        [class*="panel-"] {
+
+            @media screen and (min-width: $breakpoint-medium) {
+                @include -base-structure-grid-panel;
+            }
+
+            @media screen and (max-width: $breakpoint-medium - 1) {
+                @include -base-structure-grid-panel-collapsed;
+            }
+
+        }
+        
+        @media screen and (min-width: $breakpoint-medium) {
+            @include -base-structure-grid-panels-generate;
+        }
     
     }
 }


### PR DESCRIPTION
Consider the following:

``` html
<div class="row">
    <div class="panel-4">...</div>
    <div class="panel-4">...</div>
    <div class="panel-4">...</div>
</div>
```

As implemented currently, this will display as three equidistant panels of 33.33% width align in a horizontal arrangement with each other so long as the viewport is at least `$breakpoint-small+1`. Meanwhile, when the viewport is `$breakpoint` or less, then they become three 100% width elements aligned in a vertical arrangement.

While this behavior fits with many other grids, it's debilitating in that you may have a grid that should never collapse (scales down perfectly) or you may have a grid that is much more context sensitive and needs to collapse at a larger breakpoint.

Consequently, this pull request introduces the following collapse modifiers:
- `no-collapse`
- `xxsmall-collapse`
- `xsmall-collapse`
- `small-collapse`
- `medium-small-collapse`
- `medium-collapse`
- `medium-large-collapse`
- `large-collapse`

As an example, the following will never collapse:

``` html
<div class="row no-collapse">
    <div class="panel-6">...</div>
    <div class="panel-6">...</div>
</div>
```

Meanwhile, this will collapse at `$breakpoint-medium`:

``` html
<div class="row medium-collapse">
    <div class="panel-3">...</div>
    <div class="panel-3">...</div>
    <div class="panel-3">...</div>
    <div class="panel-3">...</div>
</div>
```

In implementing this, the following breakpoints have been defined:

``` html
$breakpoint-xxsmall:        360px !default;         /* 360px is iPhone vertical */
$breakpoint-xsmall:         480px !default;         /* 480px is iPhone horizontal */
$breakpoint-small:          600px !default;
$breakpoint-medium-small:   768px !default;         /* 768px is iPad horizontal */
$breakpoint-medium:         960px !default;
$breakpoint-medium-large:   1024px !default;        /* 1024px is iPad vertical */
$breakpoint-large:          1200px !default;
```

There are some tweaks on the existing breakpoints form the past, as well as the introduction of four new ones. The reason for introducing additional breakpoints is to make it easier to target a degradation at a particular size without forcing one to revert to their own media query definitions.

One other piece of trickery (which the SCSS is so long) comes from the fact that this implementation supports nesting rows within rows that have different cascade properties.

An example of one possible combination (all collapse combinations are supported and at any level of depth):

``` html
<div class="row small-collapse">
    <div class="panel-6">
        <div class="row medium-collapse">
            <div class="panel-6">
                A1
            </div>
            <div class="panel-6">
                A2
            </div>
        </div>
    </div>
    <div class="panel-6">
        <div class="row medium-collapse">
            <div class="panel-6">
                B1
            </div>
            <div class="panel-6">
                B2
            </div>
        </div>
    </div>
</div>
```

This markup would lead to a pair of two panels that are horizontally aligned together until `$breakpoint-small` but where their inner contents (two additional panels) degrade to horizontally aligned at `$breakpoint-medium`.

You could show the three states as:

```
[-A1-][-A2-][-B1-][-B2-]
```

```
[---A1---][---B1---]
[---A2---][---B2---]
```

```
[----A1----]
[----A2----]
[----B1----]
[----B2----]
```

@loganfranken @lnicks @chris4ucla @jeff1evesque @edsakabu @ccheung @atsengucla unless there are any issues raised with this by EOD, I'm going to merge it, since I've had #174 open with this solution complete since Friday.
