### PR TITLE
Add min-height for empty panel fix [#203]

### DIFF
--- a/src/core/adapter/base/structure/grid/_panel.scss
+++ b/src/core/adapter/base/structure/grid/_panel.scss
@@ -1,5 +1,6 @@
 @mixin -base-structure-grid-panel {
     float: left;
+    min-height: 1px;
     &.float-right {
         float: right;
     }


### PR DESCRIPTION
This pertains to #203 whereby, if a panel had nothing in it, then it would get an implicit height of zero and thus not affect the grid.
