### PR TITLE
Remove :not(.text) conditions in core adapter entity/button [fixes #212]

### DIFF
--- a/src/core/adapter/entity/_button.scss
+++ b/src/core/adapter/entity/_button.scss
@@ -70,91 +70,91 @@
         }
     }
     
-    &.primary:not(.text) {
+    &.primary {
         &:hover, &.active {
             background: $color-branding-primary-background-shadow;
             *background: darken($color-branding-primary-background-shadow, 5%);
         }
     }
     
-    &.secondary:not(.text) {
+    &.secondary {
         &:hover, &.active {
             background: $color-branding-secondary-background-shadow;
             *background: darken($color-branding-secondary-background-shadow, 5%);
         }
     }
     
-    &.tertiary:not(.text) {
+    &.tertiary {
         &:hover, &.active {
             background: $color-branding-tertiary-background-shadow;
             *background: darken($color-branding-tertiary-background-shadow, 5%);
         }
     }
     
-    &.neutral:not(.text) {
+    &.neutral {
         &:hover, &.active {
             background: $color-branding-neutral-background-shadow;
             *background: darken($color-branding-neutral-background-shadow, 5%);
         }
     }
     
-    &.info:not(.text) {
+    &.info {
         &:hover, &.active {
             background: $color-mood-info-background-shadow;
             *background: darken($color-mood-info-background-shadow, 5%);
         }
     }
     
-    &.important:not(.text) {
+    &.important {
         &:hover, &.active {
             background: $color-mood-important-background-shadow;
             *background: darken($color-mood-important-background-shadow, 5%);
         }
     }
     
-    &.success:not(.text) {
+    &.success {
         &:hover, &.active {
             background: $color-mood-success-background-shadow;
             *background: darken($color-mood-success-background-shadow, 5%);
         }
     }
     
-    &.warning:not(.text) {
+    &.warning {
         &:hover, &.active {
             background: $color-mood-warning-background-shadow;
             *background: darken($color-mood-warning-background-shadow, 5%);
         }
     }
     
-    &.error:not(.text) {
+    &.error {
         &:hover, &.active {
             background: $color-mood-error-background-shadow;
             *background: darken($color-mood-error-background-shadow, 5%);
         }
     }
     
-    &.danger:not(.text) {
+    &.danger {
         &:hover, &.active {
             background: $color-mood-danger-background-shadow;
             *background: darken($color-mood-danger-background-shadow, 5%);
         }
     }
     
-    &.inverse:not(.text) {
+    &.inverse {
         &:hover, &.active {
             background: $color-mood-inverse-background-shadow;
             *background: darken($color-mood-inverse-background-shadow, 5%);
         }
     }
     
-    &.required:not(.text) {
+    &.required {
         &:hover, &.active {
             background: $color-mood-required-background-shadow;
             *background: darken($color-mood-required-background-shadow, 5%);
         }
     }
     
-    &.highlight:not(.text) {
+    &.highlight {
         &:hover, &.active {
             background: $color-mood-highlight-background-shadow;
             *background: darken($color-mood-highlight-background-shadow, 5%);


### PR DESCRIPTION
The `:not(.text)` condition is superfluous and should be removed per #212.
