### PR TITLE
Use core adapter's .container element for Bootstrap [#182]

### DIFF
--- a/src/adapter/bootstrap/base/structure/_container.scss
+++ b/src/adapter/bootstrap/base/structure/_container.scss
@@ -8,7 +8,7 @@
                 and (max-width: $structure-container-width-max 
                                     + $structure-container-width-max 
                                         * (($structure-container-gutter*2)/100%) )
-                and (min-width: 768px) /* body applies its own padding in bootstrap */
+                and (min-width: $breakpoint-small+1)
             {                                       
                 width: 100% - ($structure-container-gutter*2);
                 padding-left: $structure-container-gutter;
@@ -17,12 +17,17 @@
             max-width: $structure-container-width-max;
         } @else {
             @media screen 
-                and (min-width: 768px) /* body applies its own padding in bootstrap */
+                and (min-width: $breakpoint-small+1)
             {                                       
                 width: 100% - ($structure-container-gutter*2);
                 padding-left: $structure-container-gutter;
                 padding-right: $structure-container-gutter;
             }
+        }
+        @media screen and (max-width: $breakpoint-small) {
+            width: auto;
+            padding-left: ($structure-container-gutter/100%) * $breakpoint-small; 
+            padding-right: ($structure-container-gutter/100%) * $breakpoint-small; 
         }
     }
 }


### PR DESCRIPTION
The `.container` element in the Bootstrap adapter should use the same code as the `.container` element established by the core adapter - except that it should wrap it in a `&:not(.bootstrap)` to allow one to still use the Bootstrap native variant as `class="container bootstrap"`.
