### PR TITLE
Fix #297 error mood semantics in Bootstrap adapter

### DIFF
--- a/src/adapter/bootstrap/entity/_button.scss
+++ b/src/adapter/bootstrap/entity/_button.scss
@@ -67,7 +67,7 @@
         @include box-shadow(#{inset 0 2px 4px rgba(0,0,0,.15), 0 1px 2px rgba(0,0,0,.05)});
     }
     
-    &:not(.primary):not(.secondary):not(.tertiary):not(.neutral):not(.info):not(.important):not(.success):not(.warning):not(.danger):not(.inverse):not(.highlight):not(.required){
+    &:not(.primary):not(.secondary):not(.tertiary):not(.neutral):not(.info):not(.important):not(.success):not(.warning):not(.error):not(.danger):not(.inverse):not(.highlight):not(.required){
         &:hover, &.active {
             background-color: $color-branding-default-background-shadow;
             *background-color: darken($color-branding-default-background-shadow, 5%);

--- a/src/adapter/bootstrap/entity/_message.scss
+++ b/src/adapter/bootstrap/entity/_message.scss
@@ -4,7 +4,7 @@
     @extend .alert;
     @extend .light;
     
-    &:not(.primary):not(.secondary):not(.tertiary):not(.neutral):not(.info):not(.important):not(.success):not(.warning):not(.danger):not(.inverse):not(.highlight):not(.required){
+    &:not(.primary):not(.secondary):not(.tertiary):not(.neutral):not(.info):not(.important):not(.success):not(.warning):not(.error):not(.danger):not(.inverse):not(.highlight):not(.required){
         @extend .light.default;
     }
 }

--- a/src/adapter/bootstrap/entity/button/_a_button.scss
+++ b/src/adapter/bootstrap/entity/button/_a_button.scss
@@ -1,7 +1,7 @@
 //!requires base/color
 
 a.button {
-    &:not(.primary):not(.secondary):not(.tertiary):not(.neutral):not(.info):not(.important):not(.success):not(.warning):not(.danger):not(.inverse):not(.highlight):not(.required){
+    &:not(.primary):not(.secondary):not(.tertiary):not(.neutral):not(.info):not(.important):not(.success):not(.warning):not(.error):not(.danger):not(.inverse):not(.highlight):not(.required){
         @include -base-color-branding-default-background;
         @include -base-color-branding-default-background-gradient;
     }

--- a/src/adapter/bootstrap/entity/button/_button.scss
+++ b/src/adapter/bootstrap/entity/button/_button.scss
@@ -1,7 +1,7 @@
 //!requires base/color
 
 button.button {
-    &:not(.primary):not(.secondary):not(.tertiary):not(.neutral):not(.info):not(.important):not(.success):not(.warning):not(.danger):not(.inverse):not(.highlight):not(.required){
+    &:not(.primary):not(.secondary):not(.tertiary):not(.neutral):not(.info):not(.important):not(.success):not(.warning):not(.error):not(.danger):not(.inverse):not(.highlight):not(.required){
         @include -base-color-branding-default-background;
         @include -base-color-branding-default-background-gradient;
     }

--- a/src/adapter/bootstrap/entity/button/_input_button.scss
+++ b/src/adapter/bootstrap/entity/button/_input_button.scss
@@ -1,7 +1,7 @@
 //!requires base/color
 
 input[type="button"].button {
-    &:not(.primary):not(.secondary):not(.tertiary):not(.neutral):not(.info):not(.important):not(.success):not(.warning):not(.danger):not(.inverse):not(.highlight):not(.required){
+    &:not(.primary):not(.secondary):not(.tertiary):not(.neutral):not(.info):not(.important):not(.success):not(.warning):not(.error):not(.danger):not(.inverse):not(.highlight):not(.required){
         @include -base-color-branding-default-background;
         @include -base-color-branding-default-background-gradient;
     }

--- a/src/adapter/bootstrap/entity/button/_input_reset.scss
+++ b/src/adapter/bootstrap/entity/button/_input_reset.scss
@@ -1,7 +1,7 @@
 //!requires base/color
 
 input[type="reset"].button {
-    &:not(.primary):not(.secondary):not(.tertiary):not(.neutral):not(.info):not(.important):not(.success):not(.warning):not(.danger):not(.inverse):not(.highlight):not(.required){
+    &:not(.primary):not(.secondary):not(.tertiary):not(.neutral):not(.info):not(.important):not(.success):not(.warning):not(.error):not(.danger):not(.inverse):not(.highlight):not(.required){
         @include -base-color-branding-default-background;
         @include -base-color-branding-default-background-gradient;
     }

--- a/src/adapter/bootstrap/entity/button/_input_submit.scss
+++ b/src/adapter/bootstrap/entity/button/_input_submit.scss
@@ -1,7 +1,7 @@
 //!requires base/color
 
 input[type="submit"].button {
-    &:not(.primary):not(.secondary):not(.tertiary):not(.neutral):not(.info):not(.important):not(.success):not(.warning):not(.danger):not(.inverse):not(.highlight):not(.required){
+    &:not(.primary):not(.secondary):not(.tertiary):not(.neutral):not(.info):not(.important):not(.success):not(.warning):not(.error):not(.danger):not(.inverse):not(.highlight):not(.required){
         @include -base-color-branding-default-background;
         @include -base-color-branding-default-background-gradient;
     }


### PR DESCRIPTION
Error button in demo isn't styled, but this wasn't because of an issue in the documentation as much as it was a bug in the Bootstrap adapter's implementation of mood colors that wasn't extended when we added `.error` semantics.
