### PR TITLE
Fix #273 add optional --offline flag for fast recompile

### DIFF
--- a/lib/Build/Package/Jquery.rb
+++ b/lib/Build/Package/Jquery.rb
@@ -39,6 +39,10 @@ module WebBlocks
           
           unless File.exists? filename
             
+            if ::WebBlocks.config[:options][:offline]
+              log.failure "Submodule", "Cannot download compiled version of jQuery in offline mode\nMust call rake the first time without --offline flag"
+            end
+            
             log.task "Package: jQuery", "Downloading compiled version of jQuery" do
               Net::HTTP.start(domain) do |http|
                 resp = http.get(path)

--- a/lib/Build/Submodule.rb
+++ b/lib/Build/Submodule.rb
@@ -14,6 +14,11 @@ module WebBlocks
       
       def init_submodule name
         
+        if ::WebBlocks.config[:options][:offline]
+          log.info "Submodule", "Skipped initializing submodule #{name} (offline mode)"
+          return
+        end
+        
         stdout = ""
         
         log.task "Submodule", "Initializing submodule #{name}" do
@@ -35,6 +40,11 @@ module WebBlocks
       end
       
       def init_submodule_submodules name
+        
+        if ::WebBlocks.config[:options][:offline]
+          log.info "Submodule", "Skipped updating submodules of submodule #{name} (offline mode)"
+          return
+        end
         
         stdout = ""
         
@@ -59,6 +69,11 @@ module WebBlocks
       end
       
       def update_submodule name
+        
+        if ::WebBlocks.config[:options][:offline]
+          log.info "Submodule", "Skipped updating submodule #{name} (offline mode)"
+          return
+        end
         
         stdout = ""
         

--- a/lib/Config.rb
+++ b/lib/Config.rb
@@ -28,6 +28,10 @@ module WebBlocks
           opts.on( '-c', '--config [OPT]', "Config file location (optional)" ) do |filename|
             options[:config] = filename || false
           end
+          options[:offline] = false
+          opts.on('--offline', '--offline', 'Offline mode for fast recompile (optional)') do
+            options[:offline] = true
+          end
         end.parse!
 
         # Load the configuration file, either Rakefile-config.rb or as specified by
@@ -35,6 +39,7 @@ module WebBlocks
         load ::WebBlocks::Path.from_root_to options[:config] ? options[:config] : 'Rakefile-config.rb'
         
         ::WebBlocks.config[:loaded] = true
+        ::WebBlocks.config[:options] = options
       
       end
       


### PR DESCRIPTION
Adds an offline flag to be invoked as:

```
rake -- --offline
```

This skips things like Git submodule init and update calls, as well as jQuery remote download. In the case of Git submodules, it simply logs a notice (although the compile will fail if the submodules have never been initialized), whereas, in the case of jQuery, if it's trying to remote download it, then it definitely isn't already present, in which case it will throw a hard fail.
