### PR TITLE
Fix #281 add --silent --details --timing flags

### DIFF
--- a/lib/Build/Dispatcher.rb
+++ b/lib/Build/Dispatcher.rb
@@ -6,6 +6,14 @@ module WebBlocks
     
     module Dispatcher
       
+      @telemetry = {:execute_time => {}}
+      
+      def self.telemetry
+        
+        @telemetry
+        
+      end
+      
       def observers 
         
         @observers = [] unless @observers
@@ -29,9 +37,15 @@ module WebBlocks
         
         ["before_#{event}", event, "after_#{event}"].each do |event|
           log.task 'Dispatcher', "Executing task: #{event}" do
+            happened = false
+            t1 = Time.now.to_f
             observers.each do |object|
-               object.send(event) if object.respond_to? event
+              next unless object.respond_to? event
+              object.send(event) 
+              happened = true
             end 
+            t2 = Time.now.to_f
+            ::WebBlocks::Build::Dispatcher.telemetry[:execute_time][event] = t2 - t1 if happened
           end
         end
         

--- a/lib/Build/Dispatcher.rb
+++ b/lib/Build/Dispatcher.rb
@@ -36,7 +36,7 @@ module WebBlocks
       def execute event
         
         ["before_#{event}", event, "after_#{event}"].each do |event|
-          log.task 'Dispatcher', "Executing task: #{event}" do
+          log.system 'Dispatcher', "Executing task: #{event}" do
             happened = false
             t1 = Time.now.to_f
             observers.each do |object|

--- a/lib/Config.rb
+++ b/lib/Config.rb
@@ -25,12 +25,20 @@ module WebBlocks
         OptionParser.new do |opts|
           opts.banner = "Usage: rake [options]"
           options[:config] = false
-          opts.on( '-c', '--config [OPT]', "Config file location (optional)" ) do |filename|
+          opts.on( '-c', '--config [OPT]', "Config file location" ) do |filename|
             options[:config] = filename || false
           end
           options[:offline] = false
-          opts.on('--offline', '--offline', 'Offline mode for fast recompile (optional)') do
+          opts.on('--offline', '--offline', 'Offline mode for fast recompile') do
             options[:offline] = true
+          end
+          options[:silent] = false
+          opts.on('--silent', '--silent', 'Print no output except errors during compile') do
+            options[:silent] = true
+          end
+          options[:timing] = false
+          opts.on('--timing', '--timing', 'Show compile timing telemetry') do
+            options[:timing] = true unless options[:silent]
           end
         end.parse!
 

--- a/lib/Config.rb
+++ b/lib/Config.rb
@@ -36,6 +36,10 @@ module WebBlocks
           opts.on('--silent', '--silent', 'Print no output except errors during compile') do
             options[:silent] = true
           end
+          options[:details] = false
+          opts.on('--details', '--details', 'Show compile process details') do
+            options[:details] = true unless options[:silent]
+          end
           options[:timing] = false
           opts.on('--timing', '--timing', 'Show compile timing telemetry') do
             options[:timing] = true unless options[:silent]

--- a/lib/Logger.rb
+++ b/lib/Logger.rb
@@ -75,7 +75,7 @@ module WebBlocks
       def write type, category, message = false
         text = message ? "[#{category}] #{message}" : "#{category}"
         text = "#{'  ' * @scope}#{text}".gsub "\n", "\n#{'  ' * @scope}"
-        puts text if @types_to_print.include? type
+        puts text if @types_to_print.include? type unless ::WebBlocks.config[:options][:silent]
         @file_handle.puts text if @types_to_file.include? type
       end
 

--- a/lib/Logger.rb
+++ b/lib/Logger.rb
@@ -21,7 +21,11 @@ module WebBlocks
         @scope = 0
         @types = [:system, :task, :failure, :success, :warning, :info, :debug]
         @type = :system
-        @types_to_print = [:system, :task, :failure, :success, :warning]
+        if ::WebBlocks.config[:options][:details]
+          @types_to_print = [:system, :task, :failure, :success, :warning]
+        else
+          @types_to_print = [:system]
+        end
         @types_to_file = [:system, :task, :failure, :success, :warning, :info, :debug]
       end
 
@@ -33,6 +37,12 @@ module WebBlocks
       def types_to_file arr
         arr = @types if arr == :all
         @types_to_file = arr
+      end
+
+      def system category, message = false
+        scope :system, category, message do
+          yield if block_given?
+        end
       end
 
       def task category, message = false

--- a/lib/Rake/Task/_after.rb
+++ b/lib/Rake/Task/_after.rb
@@ -1,0 +1,13 @@
+task :_after do
+  total_time = 0.0
+  puts "[Compiler] Execution phases ran in:" if ::WebBlocks.config[:options][:timing]
+  ::WebBlocks::Build::Dispatcher.telemetry[:execute_time].each do |idx, val|
+    puts "  [Task: #{idx}] #{(val).round 1}s" if ::WebBlocks.config[:options][:timing]
+    total_time += val
+  end
+  puts "[Compiler] Compiler ran in #{total_time.round 1}s" unless ::WebBlocks.config[:options][:silent]
+end
+
+current_tasks =  Rake.application.top_level_tasks
+current_tasks << :_after
+Rake.application.instance_variable_set(:@top_level_tasks, current_tasks)


### PR DESCRIPTION
I'm extending this to do the following:
- `--silent` no output from compiler
- `--details` shows the currently level of output
- `--timing` shows data about how long each execute call took

By default, it will no longer show verbose output but rather just the [Dispatcher] notifications and a final compile time statistic.
