### PR TITLE
Fix #276 by throwing exception on missing extension path

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -8,12 +8,12 @@
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
         
-        <link rel="stylesheet" href="asset/build/css/blocks.css">
-        <script type="text/javascript" src="asset/build/js/blocks.js"></script>
+        <link rel="stylesheet" href="../build/css/blocks.css">
+        <script type="text/javascript" src="../build/js/blocks.js"></script>
         
         <!--[if lte IE 9]>
-        <link rel="stylesheet" href="asset/build/css/blocks-ie.css">
-        <script type="text/javascript" src="asset/build/js/blocks-ie.js"></script>
+        <link rel="stylesheet" href="../build/css/blocks-ie.css">
+        <script type="text/javascript" src="../build/js/blocks-ie.js"></script>
         <![endif]-->
         
         <script type="text/javascript" src="asset/ejs.js"></script>

--- a/doc/page/configuration/troubleshoot.ejs
+++ b/doc/page/configuration/troubleshoot.ejs
@@ -128,6 +128,29 @@ Compression error encountered in /.../WebBlocks/.build-tmp/js/blocks.js</pre>
     
     <article>
         
+        <h5>Rake fails because extension does not exist</h5>
+        
+        <div>
+            
+            <p>When compiling WebBlocks, the compiler will crash if an extension specified in <code>Rakefile-config.rb</code> does not exist.</p>
+            
+            <p>An extension is regarded by WebBlocks as existing if and only if the extension directory exists. If the extension is specified by a relative path, then it is relative to <code>src/extension</code> (unless the source directory or extension source directory has been changed in <code>Rakefile-config.rb</code>). Meanwhile, if the extension is specified by an absolute path, then that directory must exist.</p>
+            
+            <p>It should be noted that the paths for relative-pathed extensions is affected by:</p>
+            
+            <ul>
+                <li><code>WebBlocks.config[:src][:dir]</code></li>
+                <li><code>WebBlocks.config[:src][:extension][:dir]</code></li>
+            </ul>
+            
+            <p>If either of these are set in <code>Rakefile-config.rb</code>, ensure that the extension directory exists in the specified locations. More on the mechanics of these configuration variables may be found in <a href="#Configuration/Compiler/Sources">Configuration/Compiler/Sources</a>.</p>
+            
+        </div>
+        
+    </article>
+    
+    <article>
+        
         <h5>Build does not include expected adapter</h5>
         
         <div>
@@ -144,29 +167,6 @@ Compression error encountered in /.../WebBlocks/.build-tmp/js/blocks.js</pre>
             </ul>
             
             <p>If either of these are set in <code>Rakefile-config.rb</code>, ensure that the adapter directory exists in the specified locations. More on the mechanics of these configuration variables may be found in <a href="#Configuration/Compiler/Sources">Configuration/Compiler/Sources</a>.</p>
-            
-        </div>
-        
-    </article>
-    
-    <article>
-        
-        <h5>Build does not include expected extension</h5>
-        
-        <div>
-            
-            <p>When compiling WebBlocks, the compiler may end up not including an extension specified in <code>Rakefile-config.rb</code>.</p>
-            
-            <p>An extension is regarded by WebBlocks as existing if and only if the extension directory exists. If the extension is specified by a relative path, then it is relative to <code>src/extension</code> (unless the source directory or extension source directory has been changed in <code>Rakefile-config.rb</code>). Meanwhile, if the extension is specified by an absolute path, then that directory must exist.</p>
-            
-            <p>It should be noted that the paths for relative-pathed extensions is affected by:</p>
-            
-            <ul>
-                <li><code>WebBlocks.config[:src][:dir]</code></li>
-                <li><code>WebBlocks.config[:src][:extension][:dir]</code></li>
-            </ul>
-            
-            <p>If either of these are set in <code>Rakefile-config.rb</code>, ensure that the extension directory exists in the specified locations. More on the mechanics of these configuration variables may be found in <a href="#Configuration/Compiler/Sources">Configuration/Compiler/Sources</a>.</p>
             
         </div>
         

--- a/lib/Build/Core/Extensions.rb
+++ b/lib/Build/Core/Extensions.rb
@@ -42,6 +42,10 @@ module WebBlocks
                   log.task "Core: Extensions", "Linking extension #{extension}" do
 
                     dir = from_src_extensions_dir_to extension
+                    
+                    unless dir and File.exists? dir
+                      log.failure "Extension #{extension} does not exist"
+                    end
 
                     get_files(dir, 'scss').sort.each do |file|
 


### PR DESCRIPTION
In the event that an extension path does not exist, then throw an error.
