### PR TITLE
Fix #299 - Rake clean task only removes blocks[-ie].[css|js] files

### DIFF
--- a/lib/Build/WebBlocks.rb
+++ b/lib/Build/WebBlocks.rb
@@ -348,8 +348,18 @@ module WebBlocks
       
       def clean
         
-        log.task "WebBlocks", "Removing build directory" do
-          FileUtils.rm_rf build_dir
+        log.task "WebBlocks", "Removing build products" do
+          
+          files = [css_build_file, css_build_file_ie, js_build_file, js_build_file_ie]
+          files.each do |file|
+            log.info "Removed #{file}" do
+              FileUtils.rm_rf file
+            end
+          end
+          
+          log.warning "This task does not clean JS scripts directory"
+          log.warning "This task does not clean img directory"
+          
         end
         
       end


### PR DESCRIPTION
This task will only clear our the CSS and JS blocks files. It will not touch images or JS scripts. If it were to attempt to, then it would have the same problem as #299 by assuming what it should be deleting. Better to be safe than sorry, albeit that this functionality is limited.

The logger output will be:

```
  [WebBlocks] Removing build products
    Removed /Applications/MAMP/htdocs/WebBlocks/build/css/blocks.css
    Removed /Applications/MAMP/htdocs/WebBlocks/build/css/blocks-ie.css
    Removed /Applications/MAMP/htdocs/WebBlocks/build/js/blocks.js
    Removed /Applications/MAMP/htdocs/WebBlocks/build/js/blocks-ie.js
    This task does not clean JS scripts directory
    This task does not clean img directory
```

It includes two warnings in case someone is trying to understand why the `clean` operation does not remove their JS scripts or img directories.
