### PR TITLE
Fix #265 - Add float-right and float-left responsive classes

### DIFF
--- a/doc/asset/doc/modules.js
+++ b/doc/asset/doc/modules.js
@@ -21,6 +21,64 @@
 				},
 				api:'Base/Block'
 			},
+			'Base/Block/Float/Responsive': {
+				description:'Defines a set of classes that set content to be floated at and below a particular breakpoint.',
+				defines: {
+					'.float-left-xxsmall':'Float content left at and below <code>$beakpoint-xxsmall</code>',
+					'.float-left-xsmall':'Float content left at and below <code>$beakpoint-xsmall</code>',
+					'.float-left-small':'Float content left at and below <code>$beakpoint-small</code>',
+					'.float-left-medium-small':'Float content left at and below <code>$beakpoint-medium-small</code>',
+					'.float-left-medium':'Float content left at and below <code>$beakpoint-medium</code>',
+					'.float-left-medium-large':'Float content left at and below <code>$beakpoint-medium-large</code>',
+					'.float-left-large':'Float content left at and below <code>$beakpoint-large</code>',
+                    '.float-right-xxsmall':'Float content right at and below <code>$beakpoint-xxsmall</code>',
+					'.float-right-xsmall':'Float content right at and below <code>$beakpoint-xsmall</code>',
+					'.float-right-small':'Float content right at and below <code>$beakpoint-small</code>',
+					'.float-right-medium-small':'Float content right at and below <code>$beakpoint-medium-small</code>',
+					'.float-right-medium':'Float content right at and below <code>$beakpoint-medium</code>',
+					'.float-right-medium-large':'Float content right at and below <code>$beakpoint-medium-large</code>',
+					'.float-right-large':'Float content right at and below <code>$beakpoint-large</code>'
+				},
+				uses:[
+					'breakpoint-xxsmall',
+					'breakpoint-xsmall',
+					'breakpoint-small',
+					'breakpoint-medium-small',
+					'breakpoint-medium',
+					'breakpoint-medium-large',
+					'breakpoint-large'
+				],
+				api:'Base/Block/Float'
+			},
+			'Base/Block/Float/Responsive_Above': {
+				description:'Defines a set of classes that set content to be hidden when viewport is <em>larger</em> than a particular breakpoint.',
+				defines: {
+					'.float-left-above-xxsmall':'Float content left above <code>$beakpoint-xxsmall</code>',
+					'.float-left-above-xsmall':'Float content left above <code>$beakpoint-xsmall</code>',
+					'.float-left-above-small':'Float content left above <code>$beakpoint-small</code>',
+					'.float-left-above-medium-small':'Float content left above <code>$beakpoint-medium-small</code>',
+					'.float-left-above-medium':'Float content left above <code>$beakpoint-medium</code>',
+					'.float-left-above-medium-large':'Float content left above <code>$beakpoint-medium-large</code>',
+					'.float-left-above-large':'Float content left above <code>$beakpoint-large</code>',
+                    '.float-right-above-xxsmall':'Float content right above <code>$beakpoint-xxsmall</code>',
+					'.float-right-above-xsmall':'Float content right above <code>$beakpoint-xsmall</code>',
+					'.float-right-above-small':'Float content right above <code>$beakpoint-small</code>',
+					'.float-right-above-medium-small':'Float content right above <code>$beakpoint-medium-small</code>',
+					'.float-right-above-medium':'Float content right above <code>$beakpoint-medium</code>',
+					'.float-right-above-medium-large':'Float content right above <code>$beakpoint-medium-large</code>',
+					'.float-right-above-large':'Float content right above <code>$beakpoint-large</code>'
+				},
+				uses:[
+					'breakpoint-xxsmall',
+					'breakpoint-xsmall',
+					'breakpoint-small',
+					'breakpoint-medium-small',
+					'breakpoint-medium',
+					'breakpoint-medium-large',
+					'breakpoint-large'
+				],
+				api:'Base/Block/Float'
+			},
 			'Base/Color': {
 				description:'Defines a set of brand-related and mood-related colors for text and backgrounds'
 			},

--- a/doc/page/api/base/block.ejs
+++ b/doc/page/api/base/block.ejs
@@ -1,12 +1,14 @@
 <h2>Block</h2>
 
-<p>This library includes modules related to block-level elements. At the current time, it includes just a single module:</p>
+<p>This library includes modules related to block-level elements. At the current time, it includes:</p>
 
 <ul class="modules">
     <li><%= DOC.modules.render('Base/Block/Float') %></li>
+    <li><%= DOC.modules.render('Base/Block/Float/Responsive') %></li>
+    <li><%= DOC.modules.render('Base/Block/Float/Responsive_Above') %></li>
 </ul>
 
-<h3>Float</h3>
+<h3>Basic Usage</h3>
 
 <p>The <code>.float-left</code> and <code>.float-right</code> classes allow one to set a left or right float on any block level element. In addition, a <code>.float-clear</code> class allows one to clear existing floats.</p>
 
@@ -19,6 +21,62 @@
     <div class="float-right secondary">.float-right</div>
     <div class="float-clear tertiary">.float-clear</div>
 </div>
+
+<h3>Responsive Usage</h3>
+
+<p>WebBlocks provides a set of classes that allow a user to float content at or below a breakpoint, whereas above the breakpoint, the element is rendered without the float:</p>
+
+<ul>
+    <li><code>.float-left-xxsmall</code></li>
+    <li><code>.float-right-xxsmall</code></li>
+    <li><code>.float-left-xsmall</code></li>
+    <li><code>.float-right-xsmall</code></li>
+    <li><code>.float-left-small</code></li>
+    <li><code>.float-right-small</code></li>
+    <li><code>.float-left-medium-small</code></li>
+    <li><code>.float-right-medium-small</code></li>
+    <li><code>.float-left-medium</code></li>
+    <li><code>.float-right-medium</code></li>
+    <li><code>.float-left-medium-large</code></li>
+    <li><code>.float-right-medium-large</code></li>
+    <li><code>.float-left-large</code></li>
+    <li><code>.float-right-large</code></li>
+</ul>
+
+<p>Similarly, WebBlocks also provides a set of classes that allow a user to float content above a breakpoint, whereas at or below the breakpoint, the element will be rendered without the float:
+
+<ul>
+    <li><code>.float-left-above-xxsmall</code></li>
+    <li><code>.float-right-above-xxsmall</code></li>
+    <li><code>.float-left-above-xsmall</code></li>
+    <li><code>.float-right-above-xsmall</code></li>
+    <li><code>.float-left-above-small</code></li>
+    <li><code>.float-right-above-small</code></li>
+    <li><code>.float-left-above-medium-small</code></li>
+    <li><code>.float-right-above-medium-small</code></li>
+    <li><code>.float-left-above-medium</code></li>
+    <li><code>.float-right-above-medium</code></li>
+    <li><code>.float-left-above-medium-large</code></li>
+    <li><code>.float-right-above-medium-large</code></li>
+    <li><code>.float-left-above-large</code></li>
+    <li><code>.float-right-above-large</code></li>
+</ul>
+
+<p>An element with <code>.float-right-medium</code> will float right at or below <code>$breakpoint-medium</code>, whereas an element <code>.float-right-above-medium</code> will only float right above <code>$breakpoint-medium</code>:</p>
+
+<pre class="prettyprint">&lt;div class="float-right-medium"&gt;
+    &lt;!-- float right at or below medium breakpoint --&gt;
+&lt;/div&gt;
+&lt;div class="float-right-above-medium"&gt;
+    &lt;!-- float right above medium breakpoint --&gt;
+&lt;/div&gt;</pre>
+
+<div class="primary float-right-medium">.float-right-medium</div>
+<br class="float-clear hide-above-medium">
+<div class="secondary float-right-above-medium">.float-right-above-medium</div>
+<br class="float-clear">
+
+<h3>Float Containers</h3>
 
 <p>In many cases, however, explicitly clearing a float is cumbersome. Therefore, WebBlocks provides two float-containing classes. These can be used to wrap floated elements so that elements later in the DOM will be flowed below the contained elements. The <code>.float-container</code> class uses the CSS overflow property to contain floats, and it works in the majority of cases. A more advanced <code>.clearfix</code> class is also provided in scenarios when <code>.float-container</code> is ineffective.</p>
 

--- a/src/core/adapter/base/block/float/_responsive.scss
+++ b/src/core/adapter/base/block/float/_responsive.scss
@@ -1,0 +1,111 @@
+@mixin -base-block-float-left-responsive-xxsmall {
+    
+    @media screen and (max-width: $breakpoint-xxsmall) {
+        float: left;
+    }
+    
+}
+
+@mixin -base-block-float-left-responsive-xsmall {
+    
+    @media screen and (max-width: $breakpoint-xsmall) {
+        float: left;
+    }
+    
+}
+
+@mixin -base-block-float-left-responsive-small {
+    
+    @media screen and (max-width: $breakpoint-small) {
+        float: left;
+    }
+    
+}
+
+@mixin -base-block-float-left-responsive-medium-small {
+    
+    @media screen and (max-width: $breakpoint-medium-small) {
+        float: left;
+    }
+    
+}
+
+@mixin -base-block-float-left-responsive-medium {
+    
+    @media screen and (max-width: $breakpoint-medium) {
+        float: left;
+    }
+    
+}
+
+@mixin -base-block-float-left-responsive-medium-large {
+    
+    @media screen and (max-width: $breakpoint-medium-large) {
+        float: left;
+    }
+    
+}
+
+@mixin -base-block-float-left-responsive-large {
+    
+    @media screen and (max-width: $breakpoint-large) {
+        float: left;
+    }
+    
+}
+
+@mixin -base-block-float-right-responsive-xxsmall {
+    
+    @media screen and (max-width: $breakpoint-xxsmall) {
+        float: right;
+    }
+    
+}
+
+@mixin -base-block-float-right-responsive-xsmall {
+    
+    @media screen and (max-width: $breakpoint-xsmall) {
+        float: right;
+    }
+    
+}
+
+@mixin -base-block-float-right-responsive-small {
+    
+    @media screen and (max-width: $breakpoint-small) {
+        float: right;
+    }
+    
+}
+
+@mixin -base-block-float-right-responsive-medium-small {
+    
+    @media screen and (max-width: $breakpoint-medium-small) {
+        float: right;
+    }
+    
+}
+
+@mixin -base-block-float-right-responsive-medium {
+    
+    @media screen and (max-width: $breakpoint-medium) {
+        float: right;
+    }
+    
+}
+
+@mixin -base-block-float-right-responsive-medium-large {
+    
+    @media screen and (max-width: $breakpoint-medium-large) {
+        float: right;
+    }
+    
+}
+
+@mixin -base-block-float-right-responsive-large {
+    
+    @media screen and (max-width: $breakpoint-large) {
+        float: right;
+    }
+    
+}

--- a/src/core/adapter/base/block/float/_responsive_above.scss
+++ b/src/core/adapter/base/block/float/_responsive_above.scss
@@ -1,0 +1,111 @@
+@mixin -base-block-float-left-responsive-above-xxsmall {
+    
+    @media screen and (min-width: $breakpoint-xxsmall+1) {
+        float: left;
+    }
+    
+}
+
+@mixin -base-block-float-left-responsive-above-xsmall {
+    
+    @media screen and (min-width: $breakpoint-xsmall+1) {
+        float: left;
+    }
+    
+}
+
+@mixin -base-block-float-left-responsive-above-small {
+    
+    @media screen and (min-width: $breakpoint-small+1) {
+        float: left;
+    }
+    
+}
+
+@mixin -base-block-float-left-responsive-above-medium-small {
+    
+    @media screen and (min-width: $breakpoint-medium-small+1) {
+        float: left;
+    }
+    
+}
+
+@mixin -base-block-float-left-responsive-above-medium {
+    
+    @media screen and (min-width: $breakpoint-medium+1) {
+        float: left;
+    }
+    
+}
+
+@mixin -base-block-float-left-responsive-above-medium-large {
+    
+    @media screen and (min-width: $breakpoint-medium-large+1) {
+        float: left;
+    }
+    
+}
+
+@mixin -base-block-float-left-responsive-above-large {
+    
+    @media screen and (min-width: $breakpoint-large+1) {
+        float: left;
+    }
+    
+}
+
+@mixin -base-block-float-right-responsive-above-xxsmall {
+    
+    @media screen and (min-width: $breakpoint-xxsmall+1) {
+        float: right;
+    }
+    
+}
+
+@mixin -base-block-float-right-responsive-above-xsmall {
+    
+    @media screen and (min-width: $breakpoint-xsmall+1) {
+        float: right;
+    }
+    
+}
+
+@mixin -base-block-float-right-responsive-above-small {
+    
+    @media screen and (min-width: $breakpoint-small+1) {
+        float: right;
+    }
+    
+}
+
+@mixin -base-block-float-right-responsive-above-medium-small {
+    
+    @media screen and (min-width: $breakpoint-medium-small+1) {
+        float: right;
+    }
+    
+}
+
+@mixin -base-block-float-right-responsive-above-medium {
+    
+    @media screen and (min-width: $breakpoint-medium) {
+        float: right;
+    }
+    
+}
+
+@mixin -base-block-float-right-responsive-above-medium-large {
+    
+    @media screen and (min-width: $breakpoint-medium-large+1) {
+        float: right;
+    }
+    
+}
+
+@mixin -base-block-float-right-responsive-above-large {
+    
+    @media screen and (min-width: $breakpoint-large+1) {
+        float: right;
+    }
+    
+}

--- a/src/core/definitions/base/block/float/_responsive.scss
+++ b/src/core/definitions/base/block/float/_responsive.scss
@@ -1,0 +1,55 @@
+.float-left-xxsmall {
+    @include -base-block-float-left-responsive-xxsmall;
+}
+
+.float-left-xsmall {
+    @include -base-block-float-left-responsive-xsmall;
+}
+
+.float-left-small {
+    @include -base-block-float-left-responsive-small;
+}
+
+.float-left-medium-small {
+    @include -base-block-float-left-responsive-medium-small;
+}
+
+.float-left-medium {
+    @include -base-block-float-left-responsive-medium;
+}
+
+.float-left-medium-large {
+    @include -base-block-float-left-responsive-medium-large;
+}
+
+.float-left-large {
+    @include -base-block-float-left-responsive-large;
+}
+
+.float-right-xxsmall {
+    @include -base-block-float-right-responsive-xxsmall;
+}
+
+.float-right-xsmall {
+    @include -base-block-float-right-responsive-xsmall;
+}
+
+.float-right-small {
+    @include -base-block-float-right-responsive-small;
+}
+
+.float-right-medium-small {
+    @include -base-block-float-right-responsive-medium-small;
+}
+
+.float-right-medium {
+    @include -base-block-float-right-responsive-medium;
+}
+
+.float-right-medium-large {
+    @include -base-block-float-right-responsive-medium-large;
+}
+
+.float-right-large {
+    @include -base-block-float-right-responsive-large;
+}

--- a/src/core/definitions/base/block/float/_responsive_above.scss
+++ b/src/core/definitions/base/block/float/_responsive_above.scss
@@ -1,0 +1,55 @@
+.float-left-above-xxsmall {
+    @include -base-block-float-left-responsive-above-xxsmall;
+}
+
+.float-left-above-xsmall {
+    @include -base-block-float-left-responsive-above-xsmall;
+}
+
+.float-left-above-small {
+    @include -base-block-float-left-responsive-above-small;
+}
+
+.float-left-above-medium-small {
+    @include -base-block-float-left-responsive-above-medium-small;
+}
+
+.float-left-above-medium {
+    @include -base-block-float-left-responsive-above-medium;
+}
+
+.float-left-above-medium-large {
+    @include -base-block-float-left-responsive-above-medium-large;
+}
+
+.float-left-above-large {
+    @include -base-block-float-left-responsive-above-large;
+}
+
+.float-right-above-xxsmall {
+    @include -base-block-float-right-responsive-above-xxsmall;
+}
+
+.float-right-above-xsmall {
+    @include -base-block-float-right-responsive-above-xsmall;
+}
+
+.float-right-above-small {
+    @include -base-block-float-right-responsive-above-small;
+}
+
+.float-right-above-medium-small {
+    @include -base-block-float-right-responsive-above-medium-small;
+}
+
+.float-right-above-medium {
+    @include -base-block-float-right-responsive-above-medium;
+}
+
+.float-right-above-medium-large {
+    @include -base-block-float-right-responsive-above-medium-large;
+}
+
+.float-right-above-large {
+    @include -base-block-float-right-responsive-above-large;
+}


### PR DESCRIPTION
Introduces the new semantics:

```
.float-left-xxsmall
.float-right-xxsmall
.float-left-xsmall
.float-right-xsmall
.float-left-small
.float-right-small
.float-left-medium-small
.float-right-medium-small
.float-left-medium
.float-right-medium
.float-left-medium-large
.float-right-medium-large
.float-left-large
.float-right-large
.float-left-above-xxsmall
.float-right-above-xxsmall
.float-left-above-xsmall
.float-right-above-xsmall
.float-left-above-small
.float-right-above-small
.float-left-above-medium-small
.float-right-above-medium-small
.float-left-above-medium
.float-right-above-medium
.float-left-above-medium-large
.float-right-above-medium-large
.float-left-above-large
.float-right-above-large
```

These behave similarly to the `hide-X` and `hide-above-X` classes. See #265 for more information.
