### PR TITLE
Fix #319 Fix #309 Fix #330 Fix #289 - Documentation updates

### DIFF
--- a/doc/component/menu/api.ejs
+++ b/doc/component/menu/api.ejs
@@ -26,6 +26,14 @@
         <li><a href="#API/Entity/List">List</a></li>
         <li><a href="#API/Entity/Table">Table</a></li>
     </ul>
+    <h1>Packages</h1>
+    <ul>
+        <li><a href="https://github.com/ebollens/efx/blob/master/README.md" target="_blank">Efx</a></li>
+        <li><a href="http://api.jquery.com" target="_blank">jQuery</a></li>
+        <li><a href="http://modernizr.com/docs/" target="_blank">Modernizr</a></li>
+        <li><a href="https://github.com/scottjehl/Respond" target="_blank">Resond.js</a></li>
+        <li><a href="http://selectivizr.com" target="_blank">Selectivizr</a></li>
+    </ul>
     <h1>Advanced</h1>
     <ul>
         <li><a href="#API/Modules">Modules List</a></li>

--- a/doc/component/menu/configuration.ejs
+++ b/doc/component/menu/configuration.ejs
@@ -3,7 +3,7 @@
     <ul>
         <li><a href="#Configuration">Overview</a></li>
         <li><a href="#Configuration/Environment">Environment</a></li>
-        <li><a href="#Configuration/Compiler">Compiler Tasks</a></li>
+        <li><a href="#Configuration/Compiler">Compiler</a></li>
         <li><a href="#Configuration/Troubleshoot">Troubleshooting</a></li>
     </ul>
     <h1>SASS Variables</h1>

--- a/doc/component/menu/core.ejs
+++ b/doc/component/menu/core.ejs
@@ -7,9 +7,9 @@
     <ul>
         <li><a href="#Core/Architecture/Terminology">Terminology</a></li>
         <li><a href="#Core/Architecture/Build">Build Process</a></li>
-        <li><a href="#Core/Architecture/Module">Adding a Module</a></li>
-        <li><a href="#Core/Architecture/Package">Adding a Package</a></li>
-        <li><a href="#Core/Architecture/Adapter">Create an Adapter</a></li>
+        <li><a href="#Core/Architecture/Module">Modules</a></li>
+        <li><a href="#Core/Architecture/Package">Packages</a></li>
+        <li><a href="#Core/Architecture/Adapter">Adapters</a></li>
     </ul>
     <h1>Contribute</h1>
     <ul>

--- a/doc/component/menu/core.ejs
+++ b/doc/component/menu/core.ejs
@@ -15,6 +15,5 @@
     <ul>
         <li><a href="#Core/Contribute/Model">Contribution Model</a></li>
         <li><a href="#Core/Contribute/Submit">Submission Process</a></li>
-        <li><a href="#Core/Contribute/Documentation">Creating Documentation</a></li>
     </ul>
 </nav>

--- a/doc/page/configuration.ejs
+++ b/doc/page/configuration.ejs
@@ -1,13 +1,110 @@
 <h2>Configuration</h2>
 
-<p>While WebBlocks may be used as a pre-built set of CSS, Javascript and images, it also includes powerful mechanisms for customization. One may modify everything from colors and the number of panels in the grid all the way down to where WebBlocks sources reside and it's build output is generated.</p>
+<p>While WebBlocks may be used as a pre-built set of CSS, Javascript and images, it also includes powerful mechanisms for customization via an easy-to-use compiler. One may modify everything from colors and the number of panels in the grid all the way down to where WebBlocks sources reside and it's build output is generated.</p>
 
-<p>On the whole, it's configuration options come in three veins:</p>
+<h3>Environment</h3>
+
+<p>The WebBlocks compiler leverages <code>rake</code>, a Ruby equivalent of GNU <code>make</code>. It also takes advantage of several other tools, such as <code>git</code>, <code>compass</code>, <code>npm</code>, <code>uglifycss</code> and <code>uglifyjs</code>. As such, the following are required:</p>
 
 <ul>
-    <li><strong>Adding your own SASS and Javascript sources.</strong> CSS (and SASS) may be added to <code>src/sass/blocks.scss</code> and <code>src/sass/blocks-ie.scss</code> or as SCSS files in <code>src/sass/blocks</code>, those for the IE CSS build suffixed with <code>-ie</code>.</li>
-    <li><strong>Modifying SASS variables to affect the way entities render.</strong> These variables should be specified in <code>src/sass/_variables.scss</code>. A full list of variables may be found in <a href="#API/Variables">API/Variables</a> and more specified details are explained in the "SASS Variables" portion of this section.</li>
-    <li><strong>Setting compiler configuration options to modify the compiler's behavior.</strong> These options are defined in <code>Rakefile-config.rb</code>. Explanations of the various options are explained in the "Compiler portion of this section.</li>
+    <li><strong><a href="https://rubygems.org" target="_blank">Ruby</a></strong> (v1.8, v1.9, v2.0), <strong><a href="https://rubygems.org" target="_blank">RubyGems</a></strong> and <strong><a href="http://gembundler.com" target="_blank">Bundler</a></strong></li>
+    <li><strong><a href="http://nodejs.org" target="_blank">Node.js</a></strong> and <strong><a href="https://npmjs.org" target="_blank">NPM</a></strong></li>
+    <li><strong><a href="http://git-scm.com" target="_blank">Git</a></strong></li>
 </ul>
 
-<p>To get started, make sure you've got your enviromnent set up correctly as described in <a href="#Configuration/Environment">Environment</a>. Going a step further, explore <a href="#Configuration/Compiler">Compiler Tasks</a> to check out different tasks the compiler will perform. Finally, explore the sources, sass variables and compiler sections for more specific details on various configuration mechanisms.</p>
+<p>With these installed, the rest of the packages used by WebBlocks may be installed via <code>git</code>, <code>bundle</code> and <code>npm</code>:</p>
+
+<pre class="prettyprint">git submodule init
+git submodule update
+bundle
+npm install</pre>
+
+<p>The WebBlocks compile, once the environment has been configured, is as simple as running <code>rake</code>:</p>
+
+<pre class="prettyprint">rake</pre>
+
+<p>More detailed installation instructions may be found in <a href="#Configuration/Environment">Environment</a>. For a description of different rake tasks and options, check out <a href="#Configuration/Compiler">Compiler Tasks</a>.</p>
+
+<h3>Configuring the Compiler</h3>
+
+<p>The compiler includes a number of configuration options that modify its behavior:</p>
+
+<ul>
+    <li>
+        <a href="#Configuration/Compiler/Components"><strong>Components</strong></a>
+        <ul>
+            <li><code>Modules</code> define WebBlocks elements</li>
+            <li><code>Adapters</code> bind WebBlocks to existing frameworks</li>
+            <li><code>Extensions</code> tweak WebBlocks definitions</li>
+            <li><code>Packages</code> are third-party components packaged with WebBlocks</li>
+        </ul>
+    </li>
+    <li>
+        <a href="#Configuration/Compiler/Build"><strong>Build Output</strong></a>
+        <ul>
+            <li><code>Debug Output</code> define whether the build is compressed or expanded</li>
+            <li><code>Build Directories</code> define to where WebBlocks assets are built</li>
+            <li><code>Build Files</code> define the names of WebBlocks built assets</li>
+        </ul>
+    </li>
+    <li>
+        <a href="#Configuration/Compiler/Sources"><strong>Sources</strong></a>
+        <ul>
+            <li><code>Source Directory</code> define location of WebBlocks sources</li>
+            <li><code>Core Directories</code> define location of WebBlocks core sources</li>
+            <li><code>Adapter Directories</code> define location of WebBlocks core sources</li>
+            <li><code>SASS Sources Directory</code> define location of user-defined SASS files</li>
+            <li><code>JS Sources Directory</code> define location of user-defined JS files</li>
+            <li><code>Image Sources Directory</code> define location of user-defined image files</li>
+        </ul>
+    </li>
+    <li>
+        <a href="#Configuration/Compiler/Advanced"><strong>Advanced</strong></a>
+        <ul>
+            <li><code>Execution Paths</code> define execution paths of required packages</li>
+            <li><code>Special Directories</code> define WebBlocks temporary and metadata directories</li>
+        </ul>
+    </li>
+</ul>
+
+<p>By default, the compiler uses <code>Rakefile-config.rb</code> for these options.</p>
+
+<p>One may specify a different configuration file via a command-line option:</p>
+
+<pre class="prettyprint">rake [task] -- --config=[config-file-path]</pre>
+
+<h3>Modifying SASS Variables</h3>
+
+<p>WebBlocks elements are set up to be highlight configurable.</p>
+
+<p>If one wishes to modify the base color used for the <code>.primary</code> branding color and it's sub-classes, the change can be made as simply as:</p>
+
+<pre class="prettyprint">$color-branding-primary: #0a2a77;</pre>
+
+<p>This line, along with any other variable definitions, should be specified in <code>src/sass/_variables.scss</code>.</p>
+
+<p>A full list of variables may be found in <a href="#API/Variables">API/Variables</a>.</p>
+
+<h3>Adding New Sources</h3>
+
+<p>Beyond WebBlocks elements, one may also add their own sources, and WebBlocks provides several ways to do this.</p>
+
+<p>To add new SASS/CSS, one may insert it into <code>src/sass/blocks.scss</code>. If one wishes for it only to load for IE6-8, then instead insert it into <code>src/sass/blocks-ie.scss</code>.</p>
+
+<p>However, placing all SASS/CSS within a single pair of files is not always reasonable. As such, WebBlocks provides several alternatives for organizing your definitions:</p>
+
+<ul>
+    <li>WebBlocks assumes that all <code>.scss</code> files within <code>src/sass</code> (except in <code>src/sass/includes</code>) are to be appended to the end of <code>blocks.scss</code> and <code>blocks-ie.scss</code> (the suffix <code>-ie</code> on a file specifying that it should go into the IE-specific sheet).</li>
+    <li>When working with additional sheets, WebBlocks variables are not automatically available, as they are compiled as separate sheets and then concatenated together. As such, variables may be loaded with <code>@import "WebBlocks-variables";</code>.</code>
+    <li>In some cases, one may wish to explicitly define load order. This may be accomplished either by prepending an <code>_</code> to a file name or placing it in the <code>src/sass/includes</code> folder, which is the only folder in <code>src/sass</code> that will not be automatically added to the build file.</li>
+</ul>
+
+<p>The rules for Javascript sources are simpler:</p>
+
+<ul>
+    <li>Place a file in <code>src/js/core</code> to have it appended to <code>blocks.js</code></li>
+    <li>Place a file in <code>src/js/core-ie</code> to have it appended to <code>blocks-ie.js</code></li>
+    <li>Place a file in <code>src/js/script</code> to have it added to the <code>script</code> build folder with a path derived from its relative orientation to <code>src/js/script</code></li>
+</ul>
+
+<p>Image assets may also be added to <code>src/img</code>, and these assets will be added to the <code>img</code> build folder with a path derived from its relative orientation to <code>src/img</code>.

--- a/doc/page/configuration/compiler.ejs
+++ b/doc/page/configuration/compiler.ejs
@@ -4,13 +4,78 @@
 
 <pre class="prettyprint">rake [task]</pre>
 
-<p>By default, this uses the <code>Rakefile-config.rb</code> file to define the compiler configuration. However, one may specify a different configuration file when invoking rake:</p>
+<h3>Compiler Configuration</h3>
+
+<p>The compiler includes a number of configuration options that modify its behavior:</p>
+
+<ul>
+    <li>
+        <a href="#Configuration/Compiler/Components"><strong>Components</strong></a>
+        <ul>
+            <li><code>Modules</code> define WebBlocks elements</li>
+            <li><code>Adapters</code> bind WebBlocks to existing frameworks</li>
+            <li><code>Extensions</code> tweak WebBlocks definitions</li>
+            <li><code>Packages</code> are third-party components packaged with WebBlocks</li>
+        </ul>
+    </li>
+    <li>
+        <a href="#Configuration/Compiler/Build"><strong>Build Output</strong></a>
+        <ul>
+            <li><code>Debug Output</code> define whether the build is compressed or expanded</li>
+            <li><code>Build Directories</code> define to where WebBlocks assets are built</li>
+            <li><code>Build Files</code> define the names of WebBlocks built assets</li>
+        </ul>
+    </li>
+    <li>
+        <a href="#Configuration/Compiler/Sources"><strong>Sources</strong></a>
+        <ul>
+            <li><code>Source Directory</code> define location of WebBlocks sources</li>
+            <li><code>Core Directories</code> define location of WebBlocks core sources</li>
+            <li><code>Adapter Directories</code> define location of WebBlocks core sources</li>
+            <li><code>SASS Sources Directory</code> define location of user-defined SASS files</li>
+            <li><code>JS Sources Directory</code> define location of user-defined JS files</li>
+            <li><code>Image Sources Directory</code> define location of user-defined image files</li>
+        </ul>
+    </li>
+    <li>
+        <a href="#Configuration/Compiler/Advanced"><strong>Advanced</strong></a>
+        <ul>
+            <li><code>Execution Paths</code> define execution paths of required packages</li>
+            <li><code>Special Directories</code> define WebBlocks temporary and metadata directories</li>
+        </ul>
+    </li>
+</ul>
+
+<p>By default, the compiler uses <code>Rakefile-config.rb</code> for these options.</p>
+
+<p>One may specify a different configuration file via a command-line options:</p>
 
 <pre class="prettyprint">rake [task] -- --config=[config-file-path]</pre>
 
-<p>This section describes the various tasks that may be used with <code>rake</code>. The <code>--config</code> option is not mentioned explicitly below, but this option is available for all tasks and, when using a non-standard configuration, it should always be specified. Details about how this can be simplified may be found in the discussion of a call-forward in the <a href="#Recipe/Integration/Submodule">Submodule Integration Recipe</a>.</p>
+<h3>Compiler Command-line Options</h3>
+
+<p>Command-line options are specified following an empty <code>--</code>, such as the <code>--config</code> option mentioned formerly:</p>
+
+<pre class="prettyprint">rake [task] -- --config=[config-file-path]</pre>
+
+<p>The following options are available:</p>
+
+<ul>
+    <li><code>--config=[FILENAME]</code> specifies location of a <code>Rakefile-config.rb</code> file</li>
+    <li><code>--silent</code> compiler will run silently (without output) unless an error if encountered</li>
+    <li><code>--details</code> compiler will show verbose details about its operations</li>
+    <li><code>--timing</code> compiler will provide information about execution times in each stage</li>
+</ul>
+
+<p>These flags may be mixed and matched. For example, if one wants detailed output with timing and has a custom <code>Rakefile-config.rb</code> file:</p>
+
+<pre class="prettyprint">rake [task] -- --config=[config-file-path] --details --timing</pre>
+
+<p>However, it is worth note that the <code>--silent</code> flag will override the <code>--details</code> and <code>--timing</code> flags. Detailed output when running in silent mode is still available in <code>build.log</code>.</p>
 
 <h3>Standard Build Rake Task</h3>
+
+<p>In addition to specifying compiler configuration options and running with command-line options, the compiler also includes a number of tasks for performing particular operations.</p>
 
 <p>The standard WebBlocks build may be invoked from the WebBlocks root as:</p>
 
@@ -57,7 +122,7 @@ git submodule update</pre>
 
 <h3>Other Rake Tasks</h3>
 
-<p>The <code>clean</code> task removes the build directory:</p>
+<p>The <code>clean</code> task removes the <code>blocks[-ie].(js|css)</code> files:</p>
 
 <pre class="prettyprint">rake clean</pre>
 

--- a/doc/page/configuration/compiler/sources.ejs
+++ b/doc/page/configuration/compiler/sources.ejs
@@ -56,7 +56,9 @@ WebBlocks.config[:src][:extension][:dir] = '#{rootdir}/src/extension'</pre>
 
 <h4>SASS Includes Sources Directory</h4>
 
-<p>The SASS includes directory is a directory that one may use to specify a set of SASS files that should be automatically included within WebBlocks when its included into <code>blocks.scss</code>. This SASS includes directory <code>blocks</code> usually resides under <code>src/sass</code> (or, if <code>WebBlocks.config[:src][:sass][:dir]</code> has been changed, then wherever this directory is):</p>
+<p>By default, all files will be automatically appended to <code>blocks.css</code> with two exceptions: those that begin with an underscore (the SASS partials scheme) and those that reside within the explicit includes directory. These latter two sets, meanwhile, may be included explicitly with the <code>@import</code> directive, allowing control over build order and the conditional addition of assets.</p>
+
+<p>This SASS includes directory <code>blocks</code> usually resides under <code>src/sass</code> (or, if <code>WebBlocks.config[:src][:sass][:dir]</code> has been changed, then wherever this directory is):</p>
 
 <pre class="prettyprint">WebBlocks.config[:src][:sass][:includes][:dir] = 'blocks'</pre>
 

--- a/doc/page/configuration/environment.ejs
+++ b/doc/page/configuration/environment.ejs
@@ -21,59 +21,61 @@
     
 </div>
 
-<div data-effect="toggle" data-toggle="slide" class="install-instructions">
+<div data-effect="toggle" data-toggle="slide" class="install-instructions" style="margin-left: 40px; margin-right: 40px; padding: 10px; border: 1px solid #ccc; text-align:justify;">
+
+    <div class="float-right"><a href="#Configuration/Environment" data-target=".install-instructions">[Close]</a></div>
     
-    <h3>Requisite Installation Instructions</h3>
+    <h4>Requisite Installation Instructions</h4>
     
     <p>These instructions are meant as a guide, but they are neither inclusive of all ways to install the requisite packages, nor will they necessarily remain the correct way to perform these installs over time.</p>
     
-    <h4>Ruby and RubyGems</h4>
+    <h5>Ruby and RubyGems</h5>
     
-    <h5>Mac OS X</h5>
+    <h6>Mac OS X</h6>
     
     <p>Ruby 1.8.7 and Rubygems are pre-installed in OS X</p>
 
-    <h5>Windows</h5>
+    <h6>Windows</h6>
 
     <p>Go to <a href="http://rubyinstaller.org" target="_blank">http://rubyinstaller.org</a> and select the RubyInstaller for 1.8.7</p>
 
     <p>Check the box for: <code>Add Ruby executable for your path</code>.</p>
 
-    <h5>Enterprise Linux (Redhat/Centos) and Fedora</h5>
+    <h6>Enterprise Linux (Redhat/Centos) and Fedora</h6>
 
     <pre class="prettyprint">yum install ruby rubygems</pre>
     
-    <h5>Debian/Ubuntu</h5>
+    <h6>Debian/Ubuntu</h6>
 
     <pre class="prettyprint">apt-get install ruby rubygems</pre>
     
-    <h4>Bundler</h4>
+    <h5>Bundler</h5>
     
     <p>Bundler is the Ruby package management system. Once you have RubyGems installed, you can simply call gem to install it:</p>
 
     <pre class="prettyprint">gem install bundler</pre>
     
-    <h4>Node.js and NPM</h4>
+    <h5>Node.js and NPM</h5>
     
-    <h5>Mac OS X</h5>
+    <h6>Mac OS X</h6>
 
     <p>Go to <a href="http://www.nodejs.org/download/" target="_blank">http://www.nodejs.org/download/</a></p>
 
-    <h5>Windows</h5>
+    <h6>Windows</h6>
 
     <p>Go to <a href="http://www.nodejs.org/download/" target="_blank">http://www.nodejs.org/download/</a></p>
 
-    <h5>Enterprise Linux (Redhat/Centos)</h5>
+    <h6>Enterprise Linux (Redhat/Centos)</h6>
 
     <pre class="prettyprint">yum localinstall --nogpgcheck http://nodejs.tchol.org/repocfg/el/nodejs-stable-release.noarch.rpm
 yum install nodejs-compat-symlinks npm</pre>
 
-    <h5>Fedora</h5>
+    <h6>Fedora</h6>
 
     <pre class="prettyprint">sudo yum localinstall --nogpgcheck http://nodejs.tchol.org/repocfg/fedora/nodejs-stable-release.noarch.rpm
 sudo yum install nodejs</pre>
     
-    <h5>Debian</h5>
+    <h6>Debian</h6>
 
     <pre class="prettyprint">apt-get install python g++ make
 mkdir ~/nodejs && cd $_
@@ -82,7 +84,7 @@ tar xzvf node-latest.tar.gz && cd `ls -rd node-v*`
 ./configure
 make install</pre>
     
-    <h5>Ubuntu</h5>
+    <h6>Ubuntu</h6>
 
     <pre class="prettyprint">apt-get install python-software-properties
 add-apt-repository ppa:chris-lea/node.js

--- a/doc/page/core/architecture/adapter.ejs
+++ b/doc/page/core/architecture/adapter.ejs
@@ -1,0 +1,240 @@
+<h2>Adapter</h2>
+
+<p>Adapters provide a way to bind between WebBlocks and a third-party UI framework. Their mechanics build upon the functionality provided by package handler, but they are more far-reaching as they do not simply lay in third-party code but actually have the ability to modify implementations of WebBlocks modules. This culminates in the fact that they have a set of SASS, JS and image sources in <code>src/adapter</code> in addition to sources in the <code>package</code>. </p>
+
+<p><span class="badge warning">NOTE</span> This document assumes familiarity with the <a href="#Core/Architecture/Module">Module</a> and <a href="#Core/Architecture/Package">Package</a> sections.</p>
+
+<h3>The Structure of an Adapter</h3>
+
+<p>An adapter is defined by:</p>
+
+<ul>
+    <li><strong>Adapter Directory</strong> that contains adapter sources.</li>
+    <li><strong>Adapter Handler</strong> that dictates how adapter operates (optional).</li>
+</ul>
+
+<p>An adapter is included such as:</p>
+
+<pre class="prettyprint">WebBlocks.config[:adapter] = 'bootstrap'</pre>
+
+<p>This informs WebBlocks to load the adapter handler in <code>lib/Build/Adapter/Bootstrap.rb</code> by the name <code>WebBlocks::Build::Adapter::Bootstrap</code>, if one exists. If not, it will use the default <code>WebBlocks::Build::Core::Adapter</code> object in <code>lib/Build/Core/Adapter.rb</code>. This is often sufficient.</p>
+
+<p>By convention, the adapter directory is usually the same as the symbol name. However, in the case of Twitter bootstrap, it is actually a bit different because of the name of the Git repository that houses the SASS fork of Bootstrap:</p>
+
+<pre class="prettyprint">WebBlocks.config[:package][:bootstrap][:dir] = 'sass-twitter-bootstrap'</pre>
+
+<p>This defines the package directory as residing at <code>package/sass-twitter-bootstrap</code> and, if using the <code>WebBlocks::Build::Submodule</code> helpers, it is required that this configuration setting be defined.</p>
+
+<h3>Example</h3>
+
+<p>The Bootstrap adapter is currently the only adapter provided with WebBlocks. However, over time, it is the hope of the WebBlocks initiative that more adapters will be written. The goal of an adapter is to bind the WebBlocks semantics with the semantics of another framework, so that there's a zero switching cost way of laying WebBlocks in place of the old framework, taking advantage of the best of both worlds. This example explains the implementation of the Bootstrap adapter.</p>
+
+<h4>Adapter Sources</h4>
+
+<p>The Bootstrap submodule is checked out within <code>package/sass-twitter-bootstrap</code>, as specified by <code>WebBlocks.config[:package][:bootstrap][:dir]</code>. However, it cannot simply be appended to the sources as with packages, as the goal is to allow tight bindings between Bootstrap and WebBlocks semantics that can only be achieved in SASS before the compiler is run.</p>
+
+<p>The first thing that is set up is a <code>src/adapter/bootstrap</code> directory.</p>
+
+<h5>Requiring Assets</h5>
+
+<p>Bootstrap establishes a number of semantics. As we want to make sure these are available in our adapter, we need to inform the linker to load them first. This is achieved through a special file placed in the root of <code>src/adapter/bootstrap</code> called <code>_require.scss</code>. When the compiler runs, it will first link the variables, then the <code>_require.scss</code> file, and only after that the core adapter, adapter overrides and core definitions.</p>
+
+<p>This <code>src/adapter/bootstrap/_require.scss</code> file includes the following:</p>
+
+<pre class="prettyprint">// Requisites for the Bootstrap adapter
+
+@import "sass-twitter-bootstrap/lib/bootstrap";
+
+// removed the following line because it duplicates imports of "mixins"
+// which include css definitions:
+//
+//      @import "sass-twitter-bootstrap/lib/responsive";
+// 
+// workaround is instead to import each responsive file individually
+
+@import "sass-twitter-bootstrap/lib/responsive-utilities";
+@import "sass-twitter-bootstrap/lib/responsive-1200px-min";
+@import "sass-twitter-bootstrap/lib/responsive-768px-979px";
+@import "sass-twitter-bootstrap/lib/responsive-767px-max";
+@import "sass-twitter-bootstrap/lib/responsive-navbar";
+
+/**
+ * Version of @mixin gradientBar without border tweaks
+ */
+@mixin gradientBarSimple($primaryColor, $secondaryColor, $textColor: #fff, $textShadow: 0 -1px 0 rgba(0,0,0,.25)) {
+  color: $textColor;
+  text-shadow: $textShadow;
+  @include gradient-vertical($primaryColor, $secondaryColor);
+}</pre>
+
+<p>In some cases, the <code>_require.scss</code> file will be simpler, just including a single SCSS file from the third-party adapter. However, in the case of Bootstrap, since WebBlocks uses a port from LESS, it includes a couple hacks to deal with a bug in utilities and to fix an issue with the Bootstrap mixin <code>gradientBarSimple</code>. Generally, the concept of <code>_require.scss</code> is to load those assets which define the third-party code itself but not the WebBlocks bindings.</p>
+
+<h5>Variables</h5>
+
+<p>WebBlocks loads <code>_variables.scss</code> files before it loads anything else, including <code>_require.scss</code> files. This means that we can use the <code>src/adapter/bootstrap/_variables.scss</code> file to set variables for both WebBlocks <em>and</em> Bootstrap. In the case of Bootstrap, the predominant use of this file is to define Bootstrap settings so they function smoothly with the WebBlocks settings:</p>
+
+<pre class="prettyprint">$horizontalComponentOffset:         $form-horizontal-offset;
+
+$btnBackground:                     $color-branding-default-background;
+$btnBackgroundHighlight:            $color-branding-default-background-shadow;
+$btnBorder:                         #bbb;
+
+$btnInfoBackground:                 $color-mood-info-background;
+$btnInfoBackgroundHighlight:        $color-mood-info-background-shadow;
+
+$btnSuccessBackground:              $color-mood-success-background;
+$btnSuccessBackgroundHighlight:     $color-mood-success-background-shadow;
+
+$btnWarningBackground:              $color-mood-warning-background;
+$btnWarningBackgroundHighlight:     $color-mood-warning-background-shadow;
+
+$btnDangerBackground:               $color-mood-danger-background;
+$btnDangerBackgroundHighlight:      $color-mood-danger-background-shadow;
+
+$btnInverseBackground:              $color-mood-inverse-background;
+$btnInverseBackgroundHighlight:     $color-mood-inverse-background-shadow;
+
+$gridColumns:                       $structure-panels;
+$fluidGridColumnWidth:              $structure-panel-width;
+$fluidGridGutterWidth:              $structure-panel-gutter;
+
+$warningText:                       $color-mood-warning-background-light-text;
+$warningBackground:                 $color-mood-warning-background-light-shadow;
+$warningBorder:                     $color-mood-warning-light-border;
+
+$errorText:                         $color-mood-danger-background-light-text;
+$errorBackground:                   $color-mood-danger-background-light-shadow;
+$errorBorder:                       $color-mood-danger-light-border;
+
+$successText:                       $color-mood-success-background-light-text;
+$successBackground:                 $color-mood-success-background-light-shadow;
+$successBorder:                     $color-mood-success-light-border;
+
+$infoText:                          $color-mood-info-background-light-text;
+$infoBackground:                    $color-mood-info-background-light-shadow;
+$infoBorder:                        $color-mood-info-light-border;
+
+$tableBackgroundHover:              $table-hover-background-color;
+$tableBackgroundAccent:             $table-striped-background-color;
+$tableBorder:                       $table-border-color;</pre>
+
+<p>While semantics load in the order <code>core adapter -> third-party adapter -> core definitions -> extensions -> user-defined files</code>, variables load in the reverse order (to ensure accurate overriding properties), meaning that by the time the <code>_variables.scss</code> file is reached for the Bootstrap adapter, all of the WebBlocks variables will have already been loaded, which is why this is possible.</p>
+
+<h5>Overriding Mixins</h5>
+
+<p>The key role of an adapter is to override default mixins with those that bind the third-party framework to WebBlocks. Adapters should use the same directory structure for their mixins as the core adapter does, namely using the directory structure to define the module layout (for more information on this, see <a href="#Core/Architecture/Module">Module</a>).</p>
+
+<p>Working from the example in the <a href="#Core/Architecture/Module">Module</a> section regarding <code>Base/Type/Align</code>, Bootstrap provides two alignment classes synonymous to WebBlocks alignment classes:</p>
+
+<ul>
+    <li><code>.pagination-centered</code></li>
+    <li><code>.pagination-right</code></li>
+</ul>
+
+<p>To explicitly bind these two classes, the file <code>src/adapter/bootstrap/base/type/_align.scss</code> may redefine the mixins that power both of these definitions:</p>
+
+<pre class="prettyprint">@mixin -base-type-align-center {
+    @extend .pagination-centered;
+}
+
+@mixin -base-type-align-right {
+    @extend .pagination-right;
+}</pre>
+
+<p>Because the adapter mixins override the core mixins (and adapter mixins earlier in the adapter queue), this means that these mixins will override the core mixins such that final output of the <code>Base/Type/Align</code> module will end up as:</p>
+
+<pre class="prettyprint">/* .. */
+.pagination-centered, .text-center { /* bootstrap implementation */ }
+.pagination-right, .text-right { /* bootstrap implementation */ }
+/* .. */
+.text-left { text-align: left; }
+.text-justify { text-align: justify; }
+/* .. */</pre>
+
+<p>While mixins may be as simple as an <code>@extend</code>, in reality, one can do just about anything with one.</p>
+
+<p>For example, Bootstrap has separate classes for <code>.badge</code> and <code>.label</code>, whereas WebBlocks avoids the class <code>.label</code> because it is a namespace conflict with the <code>label</code> element and instead provides style modifiers on <code>.badge</code>. Consequently, the default badge in WebBlocks has slightly rounded corners, synonymous to the label in Bootstrap. To rectify this discrepancy, the Bootstrap adapter can use it's existing <code>.badge</code> implementation (which propagates through that sheet's including via <code>_require.scss</code>) and then it just uses the mixin to make a minor tweak:</p>
+
+<pre class="prettyprint">@mixin -entity-badge {
+    border-radius: 4px;
+}</pre>
+
+<p>A more advanced example comes from <code>Entity/Message</code>. Bootstrap provides an <code>.alert</code> class that has some of the functionality of the WebBlocks <code>.message</code> class, but the WebBlock's class has additional aspects such as it's handling of color. The implementation in <code>src/adapter/bootstrap/entity/_message.scss</code> is thus:</p>
+
+<pre class="prettyprint">//!requires base/color
+
+@mixin -entity-message {
+    @extend .alert;
+    @extend .light;
+    
+    &:not(.primary):not(.secondary):not(.tertiary):not(.neutral):not(.info):not(.important):not(.success):not(.warning):not(.error):not(.danger):not(.inverse):not(.highlight):not(.required){
+        @extend .light.default;
+    }
+}</pre>
+
+<p>The pre-compiler directive <code>//!requires</code> is explained in <a href="#Core/Architecture/Module">Module</a>.
+
+<h4>Adapter Handler</h4>
+
+<p>The adapter handler is very synonymous to the package handler, in that it is responsible for managing the third-party module and assembling the necessary assets. However, it does have a few key differences:</p>
+
+<ul>
+    <li>An adapter handler <em>does not</em> necessarily need to be specified. If it is built using the conventional layout of an adapter and it does not assemble additional assets, and no adapter handler exists, WebBlocks will fall back to using the <code>WebBlocks::Build::Core::Adapter</code> handler. However, in the case of Bootstrap, since it also includes Javascript assets, the handler is explicitly defined.</li>
+    <li>Adapter handlers reside in <code>lib/Build/Adapter/[name].rb</code> by the object name <code>WebBlocks::Build::Adapter::[name]</code>.</li>
+    <li>Adapter handlers should invoke the <code>resolve_sass_dependencies</code> method in their <code>preprocess_css</code> method. This allows the dependency manager to process all <code>//!requires</code> pre-compiler directives specified within the adapter sources.</li>
+    <li>Adapter handlers should invoke the <code>link_sass_libs_for</code> method in their <code>compile_css</code> method. This allows the linker to add SASS sources from the adapter directory into the build at the correct point in precedence order.</li>
+</ul>
+
+<p>This section does not replicate the explanation of methods provided in <a href="#Core/Architecture/Module">Module</a> but instead focuses only on the key differences from the way the module handler works.</p>
+
+<p>The <code>preprocess_css</code> step should minimally resolve SASS dependencies:</p>
+
+<pre class="prettyprint">        def preprocess_css
+          log.task "Adapter: Bootstrap", "Resolving SASS dependenties in Bootstrap adapter" do
+            resolve_sass_dependencies src_adapter_dir :bootstrap 
+          end
+        end</pre>
+
+<p>The <code>link_css</code> step should minimally link SASS libraries:</p>
+
+<pre class="prettyprint">        def link_css
+          log.task "Adapter: Bootstrap", "Linking bootstrap adapter" do
+            link_sass_libs_for src_adapter_dir :bootstrap
+          end
+        end</pre>
+
+<p>Both of these steps are <em>module-aware</em>, meaning that they will only resolve dependencies and link modules that are actually specified for inclusion by the compiler.</p>
+
+<p>As mentioned above, adapters do not actually need an adapter handler in all cases. If they just include SASS sources and use the correct directory and configuration layout, they may simply use the default adapter handler <code>WebBlocks::Build::Core::Adapter</code>. However, the steps that require a custom adapter for Bootstrap are related to the fact that Bootstrap includes image and JS assets as well:</p>
+
+<pre class="prettyprint">        def assemble_img
+          dir = "#{package_dir :bootstrap}/img"
+          log.task "Adapter: Bootstrap", "Copying images from Bootstrap package" do
+            get_files(dir).each do |file|
+              log.debug "#{tmp_img_build_dir.gsub /^#{root_dir}\//, ''} <- #{file.gsub /^#{root_dir}\//, ''}"
+              FileUtils.cp_r file, "#{tmp_img_build_dir}/#{file.gsub /^#{dir}\//, ''}"
+            end
+          end
+          log.task "Adapter: Bootstrap", "Copying images from Bootstrap adapter" do
+            assemble_img_files_for src_adapter_dir :bootstrap
+          end
+        end
+        
+        def assemble_js
+          base = "#{package_dir :bootstrap}/js/bootstrap"
+          log.task "Adapter: Bootstrap", "Copying JS from Bootstrap package" do
+            scripts = config[:package][:bootstrap][:scripts] ? config[:package][:bootstrap][:scripts] : []
+            scripts.each do |script|
+              file = "#{base}-#{script}.js"
+              if File.exists? file
+                log.debug "#{tmp_js_build_file.gsub /^#{root_dir}\//, ''} <<- #{file.gsub /^#{root_dir}\//, ''}"
+                append_file file, tmp_js_build_file
+              end
+            end
+          end
+          log.task "Adapter: Bootstrap", "Copying JS from Bootstrap adapter" do
+            assemble_js_libs_for src_adapter_dir :bootstrap
+          end
+        end</pre>
+
+<p>Not all third-party adapters will require these extra steps, hence why in some cases an adapter handler is not necessary.</p>

--- a/doc/page/core/architecture/module.ejs
+++ b/doc/page/core/architecture/module.ejs
@@ -1,0 +1,292 @@
+<h2>Module</h2>
+
+<p>Modules provide a structure for WebBlocks definitions. A module may be a leaf node, defining a single set of semantics, or a namespace containing multiple submodules. For instance, the <code>Entity/Form</code> module contains all of the semantic structures defined for forms, while the <code>Base/Structure</code> module actually contains several submodules including <a href="#API/Base/Structure/Container">Base/Structure/Container</a>, <a href="#API/Base/Structure/Grid">Base/Structure/Grid</a> and <a href="#API/Base/Structure/Constrained">Base/Structure/Constrained</a>.</p>
+
+<p>This section uses the <code>Base/Type/Align</code> module to explain how a module is implemented.</p>
+
+<p><span class="badge warning">NOTE</span> This document assumes familiarity with the <a href="#Core/Architecture/Terminology">Terminology</a> section.</p>
+
+<h3>The Structure of a Module</h3>
+
+<p>A module is minimally defined by two files:</p>
+
+<ul>
+    <li><strong>Core Definition</strong> that defines the interface.</li>
+    <li><strong>Core Adapter</strong> that defines the default implementation.</li>
+</ul>
+
+<p>Additionally, a module may be modified by an <strong>Adapter</strong> when WebBlocks is compiled with that adapter.</p>
+
+<p>The name of a module is defined by it's pathing. The <code>Base/Type/Align</code> module is found in <code>base/type/_align.scss</code> <i>relative</i> to the core definition, core adapter and adapter directories.</p>
+
+<h4>Core Definition File</h4>
+
+<p>The <code>Base/Type/Align</code> module includes four classes:</p>
+
+<ul>
+    <li><code>.text-left</code></li>
+    <li><code>.text-center</code></li>
+    <li><code>.text-right</code></li>
+    <li><code>.text-justify</code></li>
+</ul>
+
+<p>The core definition in <code>src/core/definition/base/type/_align.scss</code> is thus:</p>
+
+<pre class="prettyprint">.text-left {
+    @include -base-type-align-left;
+}
+
+.text-center {
+    @include -base-type-align-center;
+}
+
+.text-right {
+    @include -base-type-align-right;
+}
+
+.text-justify {
+    @include -base-type-align-justify;
+}</pre>
+
+<p>It is worth note that this definition file <em>does not</em> include the actual CSS. Instead, it invokes SASS mixins via <code>@include</code>. The reason for this is that, by using a mixin, the actual definition may come either from the core adapter or from another adapter that overrides the behavior of the class.</p>
+
+<h4>Core Adapter File</h4>
+
+<p>The core adapter specified the default implementation (unless the mixin is overridden by an adapter).</p>
+
+<p>As stipulated by the core definition, the core adapter must specify four mixins:</p>
+
+<ul>
+    <li><code>-base-type-align-left</code></li>
+    <li><code>-base-type-align-center</code></li>
+    <li><code>-base-type-align-right</code></li>
+    <li><code>-base-type-align-justify</code></li>
+</ul>
+
+<p>The core adapter mixins definitions in <code>src/core/adapter/base/type/_align.scss</code> are thus:</p>
+
+<pre class="prettyprint">@mixin -base-type-align-left {
+    text-align: left;
+}
+
+@mixin -base-type-align-center {
+    text-align: center;
+}
+
+@mixin -base-type-align-right {
+    text-align: right;
+}
+
+@mixin -base-type-align-justify {
+    text-align: justify;
+}</pre>
+
+<p>By convention, the mixins should always begin with the module namespace (using hyphens instead of slashes for pathing, as slashes are not an allowed character in SASS mixin names).</p>
+
+<h4>Assembling the Core</h4>
+
+<p>When the compiler runs, figuring that there are no overrides in any adapters it includes, it will first load the core adapter and then the core definition:</p>
+
+<pre class="prettyprint">/* .. */
+@import "[base-path]/src/core/adapter/base/type/_align.scss";
+/* .. */
+@import "[base-path]/src/core/definition/base/type/_align.scss";
+/* .. */</pre>
+
+<p>Expanded, this becomes:</p>
+
+<pre class="prettyprint">/* .. */
+@mixin -base-type-align-left { text-align: left; }
+@mixin -base-type-align-center { text-align: center; }
+@mixin -base-type-align-right { text-align: right; }
+@mixin -base-type-align-justify { text-align: justify; }
+/* .. */
+.text-left { @include -base-type-align-left; }
+.text-center { @include -base-type-align-center; }
+.text-right { @include -base-type-align-right; }
+.text-justify { @include -base-type-align-justify; }
+/* .. */</pre>
+
+<p>Compiled, the final result is:</p>
+
+<pre class="prettyprint">/* .. */
+.text-left { text-align: left; }
+.text-center { text-align: center; }
+.text-right { text-align: right; }
+.text-justify { text-align: justify; }
+/* .. */</pre>
+
+<h4>Adapter Overrides</h4>
+
+<p>The reason that interface and implementation are separated is because of the power WebBlocks gives to adapters. Adapters, simply put, provide a way to bridge a third-party package with WebBlocks, using implementation from the package to implement components of WebBlocks for a smoother experience.</p>
+
+<h5>Adapter Implementation File</h5>
+
+<p>In the case of Twitter Bootstrap, it provides two alignment classes:</p>
+
+<ul>
+    <li><code>.pagination-centered</code></li>
+    <li><code>.pagination-right</code></li>
+</ul>
+
+<p>To leverage these two classes, the Bootstrap adapter overrides two of the mixins for type alignment in the file <code>src/adapter/bootstrap/base/type/_align.scss</code>:</p>
+
+<pre class="prettyprint">@mixin -base-type-align-center {
+    @extend .pagination-centered;
+}
+
+@mixin -base-type-align-right {
+    @extend .pagination-right;
+}</pre>
+
+<p>While <code>@extend</code> is used in both of these overrides, any SASS/CSS may be used including <code>@include</code> or standard CSS.</p>
+
+<h5>Assembling with an Adapter</h5>
+
+<p>When the compiler runs with an adapter specifying overrides, it will first load the core adapter, then the other adapters (in FIFO order) and finally the core definition:</p>
+
+<pre class="prettyprint">/* .. */
+@import "[base-path]/src/core/adapter/base/type/_align.scss";
+/* .. */
+@import "[base-path]/src/adapter/bootstrap/base/type/_align.scss";
+/* .. */
+@import "[base-path]/src/core/definition/base/type/_align.scss";
+/* .. */</pre>
+
+<p>Expanded, this becomes:</p>
+
+<pre class="prettyprint">/* .. */
+@mixin -base-type-align-left { text-align: left; }
+@mixin -base-type-align-center { text-align: center; }
+@mixin -base-type-align-right { text-align: right; }
+@mixin -base-type-align-justify { text-align: justify; }
+/* .. */
+@mixin -base-type-align-center { @extend .pagination-centered; }
+@mixin -base-type-align-right { @extend .pagination-right; }
+/* .. */
+.text-left { @include -base-type-align-left; }
+.text-center { @include -base-type-align-center; }
+.text-right { @include -base-type-align-right; }
+.text-justify { @include -base-type-align-justify; }
+/* .. */</pre>
+
+<p>Removing the overridden mixins, this becomes:</p>
+
+<pre class="prettyprint">/* .. */
+@mixin -base-type-align-left { text-align: left; }
+@mixin -base-type-align-justify { text-align: justify; }
+/* .. */
+@mixin -base-type-align-center { @extend .pagination-centered; }
+@mixin -base-type-align-right { @extend .pagination-right; }
+/* .. */
+.text-left { @include -base-type-align-left; }
+.text-center { @include -base-type-align-center; }
+.text-right { @include -base-type-align-right; }
+.text-justify { @include -base-type-align-justify; }
+/* .. */</pre>
+
+<p>Compiled, the final result is:</p>
+
+<pre class="prettyprint">/* .. */
+.pagination-centered, .text-center { /* bootstrap implementation */ }
+.pagination-right, .text-right { /* bootstrap implementation */ }
+/* .. */
+.text-left { text-align: left; }
+.text-justify { text-align: justify; }
+/* .. */</pre>
+
+<h3>Submodules</h3>
+
+<p>When working with <code>Rakefile-config.rb</code>, one often takes advantage of the implicit way in which WebBlocks supports submodules. Essentially, when a module is loaded, WebBlocks seeks out SASS files bearing the name of the module, as well as within a directory by the module's name.</p>
+
+<p>The <code>Base/Type/Align</code> module happens to actually have submodules. When the module <code>Base/Type/Align</code> is specified, WebBlocks seeks out the following paths (relative to the core definition, core adapter and third-party adapter directories):
+
+<ul>
+    <li><code>base/type/_align.scss</code></li>
+    <li><code>base/type/align/*.scss</code></li>
+    <li><code>base/type/align/*/*.scss</code></li>
+</ul>
+
+<p>In the case of <code>Base/Type/Align</code>, WebBlocks will resolve three paths:</p>
+
+<ul>
+    <li><code>base/type/_align.scss</code></li>
+    <li><code>base/type/align/_responsive.scss</code></li>
+    <li><code>base/type/align/_responsive_above.scss</code></li>
+</ul>
+
+<p>The has the result of actually loading three leaf nodes:</p>
+
+<ul>
+    <li><code>Base/Type/Align</code></li>
+    <li><code>Base/Type/Align/Responsive</code></li>
+    <li><code>Base/Type/Align/Responsive_Above</code></li>
+</ul>
+
+<h3>Variables</h3>
+
+<p>Arguably, the usefulness of a module stems from the ability to configure it fully. As such, modules are encouraged to use variables and define a default set in a <code>_variables.scss</code> file.</p>
+
+<p>By convention, <code>_variables.scss</code> files should not include anything except variables, and therefore WebBlocks is a little lighter on the way in which it seeks out variables. Essentially, for a module, it will load all <code>_variables.scss</code> files for both containing namespaces and contained submodules.</p>
+
+<p>The <code>Base/Type/Align/Responsive</code> and <code>Base/Type/Align/Responsive_Above</code> submodules both use a number of variables, namely <code>$breakpoint-xxsmall</code>, <code>$breakpoint-xsmall</code>, <code>$breakpoint-small</code>, etc. When loading <code>Base/Type/Align</code> (and thus the submodules that need variables), WebBlocks will include variables files (if they exist) from:</p>
+
+<ul>
+    <li><code>./_variables.scss</code></li>
+    <li><code>./base/_variables.scss</code></li>
+    <li><code>./base/type/_variables.scss</code></li>
+    <li><code>./base/type/align/_variables.scss</code></li>
+    <li><code>./base/type/align/*/_variables.scss</code></li>
+</ul>
+
+<p>These paths are relative to <code>src/core/definition</code>, <code>src/core/adapter</code>, and any third-party module included in the compile.</p>
+
+<h3>Dependencies</h3>
+
+<p>In some cases, a module may depend on another module. SASS does not have a concept of this, and we cannot use <code>@import</code> because of the fact WebBlocks loads a variable set of files based on adapters. As such, WebBlocks introduces a <strong>pre-compiler directive</strong> to stipulate this requisite:</p>
+
+<pre class="prettyprint">//!requires [MODULENAME]</pre>
+
+<p>The <code>Base/Type/Align</code> module does not have any requisites, so instead our example here shall refer to the <code>Base/Color/Branding/Background_Gradient</code> module. Essentially, this module defines a <code>.gradient</code> semantic that can be applied to a branding color such as <code>.primary</code>. However, since the <code>Base/Color/Branding/Background_Gradient</code> module does not actually define the <code>.primary</code> semantic, instead it must define a dependency in <code>src/definitions/base/color/branding/_background_gradient.scss</code>:</p>
+
+<pre class="prettyprint">//!requires base/color/branding/background
+
+.gradient {
+        
+    &.default {
+        @include -base-color-branding-default-background-gradient;
+    }
+        
+    &.primary {
+        @include -base-color-branding-primary-background-gradient;
+    }
+        
+    &.secondary {
+        @include -base-color-branding-secondary-background-gradient;
+    }
+        
+    &.tertiary {
+        @include -base-color-branding-tertiary-background-gradient;
+    }
+        
+    &.neutral {
+        @include -base-color-branding-neutral-background-gradient;
+    }
+
+}</pre>
+
+<p>In some cases, a dependency may stem, not from a semantic requirement (such as <code>.primary</code> needed for <code>.primary.gradient</code>) but instead from an implementation requirement. In such a case, the requires pre-compiler directive should be stated in the implementation file. For example, the <code>Entity/Button</code> implementation in <code>src/core/adapter/entity/_button.scss</code> is as follows (with unrelated code removed for brevity):</p>
+
+<pre class="prettyprint">//!requires base/color
+
+/* .. */
+
+@mixin -entity-button { 
+    
+    @extend .gradient;
+
+    /* .. */
+
+}</pre>
+
+<p>The compiler includes a dependency resolver that will load all required modules before the modules that require them. In the event that a cyclical dependency is encountered (one where two modules require each other), the compiler will throw a warning. When crafting modules, one should work hard to avoid creating such cycles.</p>

--- a/doc/page/core/architecture/package.ejs
+++ b/doc/page/core/architecture/package.ejs
@@ -1,0 +1,302 @@
+<h2>Package</h2>
+
+<p>Pacakges provide a way to load in a third-party module. Traditionally, they are checked out as Git submodules, although WebBlocks leaves the exact mechanics for retrieving and maintaining the third-party code to the package handler.</p> 
+
+<p><span class="badge warning">NOTE</span> This document assumes familiarity with the <a href="#Core/Architecture/Terminology">Terminology</a> and <a href="#Core/Architecture/Build">Build Process</a> sections.</p>
+
+<h3>The Structure of a Package</h3>
+
+<p>A package is minimally defined by:</p>
+
+<ul>
+    <li><strong>Package Directory</strong> that contains third-party assets.</li>
+    <li><strong>Package Handler</strong> that dictates how package is assembled.</li>
+</ul>
+
+<p>A package is included such as:</p>
+
+<pre class="prettyprint">WebBlocks.config[:src][:packages] << :respond</pre>
+
+<p>This informs WebBlocks to load the package handler in <code>lib/Build/Package/Respond.rb</code> by the name <code>WebBlocks::Build::Package::Respond</code>.</p>
+
+<p>By convention, the package directory is usually the same as the symbol name:</p>
+
+<pre class="prettyprint">WebBlocks.config[:package][:respond][:dir] = 'respond'</pre>
+
+<p>This defines the package directory as residing at <code>package/respond</code> and, if using the <code>WebBlocks::Build::Submodule</code> helpers, it is required that this configuration setting be defined.</p>
+
+<h3>Basic Package</h3>
+
+<p>The simplest type of package is one that can be checked out as a Git submodule and then it's sources simply appended to the CSS and JS build files. An example of this is the <code>respond</code> package, which polyfills CSS 3 <code>@media</code> selectors for IE 6-8.</p>
+
+<h4>Package Directory</h4>
+
+<p>In the case of <code>Respond.js</code>, the package is a submodule in <code>package/respond</code>.</p>
+
+<p>When developed, this submodule was set up as:</p>
+
+<pre>git submodule add https://github.com/scottjehl/Respond.git package/respond</pre>
+
+<p>When a user clones the WebBlocks Git repository, this is pulled in via:</p>
+
+<pre>git submodule init
+git submodule update</pre>
+
+<p>In the event that this is not done, the package handler attempts to handle it internally.</p>
+
+<h4>Package Handler</h4>
+
+<p>When <code>respond</code> is set in <code>WebBlocks.config[:src][:packages]</code> (by default, it's enabled, or when included as <code>WebBlocks.config[:src][:packages] << :respond</code>), the package handler is attached to the <a href="#Core/Architecture/Build">build process</a>. This means that, as the compiler executes a stage, if the handler implements a particular method, it will be invoked.</p>
+
+<p>In the case of <code>respond</code>, the code is purely Javascript, so the events that we clearly want to respond to are:</p>
+
+<ul>
+    <li><code>preprocess_js</code></li>
+    <li><code>assemble_js</code></li>
+</ul>
+
+<p>In addition, we also need to respond to the non-<code>_js</code> equivalents, since WebBlocks does not automatically dispatch <code>build</code> requests to <code>build_js</code> (as there might be reasons that the two processes are not the same). Consequently, this handler must also respond to:</p>
+
+<ul>
+    <li><code>preprocess</code></li>
+    <li><code>assemble</code></li>
+</ul>
+
+<p>Finally, since this module involves pulling down third-party components, it should also respond to:</p>
+
+<ul>
+    <li><code>reset_package</code></li>
+</ul>
+
+<p>The implementation for this resides in <code>lib/Build/Package/Respond.rb</code>:</p>
+
+<pre class="prettyprint">require 'rubygems'
+require 'extensions/kernel' if defined?(require_relative).nil?
+require_relative '../../Path'
+require_relative '../Submodule'
+require_relative '../Utilities'
+require_relative '../../Logger'
+
+module WebBlocks
+  module Build
+    module Package
+      class Respond
+        
+        include ::WebBlocks::Logger
+        include ::WebBlocks::Path::Temporary_Build
+        include ::WebBlocks::Build::Submodule
+        include ::WebBlocks::Build::Utilities
+        
+        def preprocess
+          # call-forward
+          preprocess_js
+        end
+        
+        def preprocess_js
+          # git submodule init + update
+          preprocess_submodule :respond
+        end
+        
+        def assemble
+          # callforward
+          assemble_js
+        end
+        
+        def assemble_js
+          # initiate a task within logger scope
+          log.task "Package: Respond", "Copying Respond sources to IE JS build file" do
+            # append respond's respond.src.js file to tmp_js_build_file_ie
+            file = "#{package_dir :respond}/respond.src.js"
+            log.debug "#{tmp_js_build_file_ie.gsub /^#{root_dir}\//, ''} <<- #{file.gsub /^#{root_dir}\//, ''}"
+            append_file file, tmp_js_build_file_ie
+          end
+        end
+        
+        def reset_package
+          # delete submodule contents
+          reset_submodule :respond
+        end
+        
+      end
+    end
+  end
+end</pre>
+
+<p>The functions <code>preprocess_submodule</code> and <code>reset_submodule</code> are helpers that, based on <code>WebBlocks.config[:package][:respond][:dir]</code>, will perform submodule maintenance. The former will do a <code>git submodule init</code> and <code>git submodule update</code> on the package directory, whereas the latter will delete the package directory.</p>
+
+<p>The function <code>log.task</code> is one of the functions defined in <code>WebBlocks::Logger</code> that defines the scope of a series of events at the log level of <code>task</code>. In addition to task, the logger exposes a number of other levels including <code>system</code>, <code>failure</code>, <code>success</code>, <code>warning</code>, <code>info</code>, and <code>debug</code>.</p>
+
+<p>The implementations of <code>preprocess</code> and <code>assemble</code>, true to as mentioned above, are simply call-forwards respectively to <code>preprocess_js</code> and <code>assemble_js</code>.
+
+<p>Finally, the actual action performed here (besides submodule maintenance in <code>preprocess_js</code> and <code>reset_package</code>) is done in <code>assemble_js</code>, whereby this particular module simply appends the contents of the <code>respond.src.js</code> file into the <code>tmp_js_build_file_ie</code>. In addition to appending to this file, one can also append to a number of other files defined in <code>lib/Path/Temporary_Build.rb</code>.</p>
+
+<h3>Basic Package with Custom Assembly</h3>
+
+<p>The <code>efx</code> package is roughly synonymous to <code>respond</code>, with the caveat that it comes as an unassembled set of Javascript files. For this reason, the <code>assemble_js</code> method has to do a bit more work.</p>
+
+<p>The handler in <code>lib/Build/Package/Efx.rb</code> is thus a bit more complex:</p>
+
+<pre class="prettyprint">require 'rubygems'
+require 'extensions/kernel' if defined?(require_relative).nil?
+require_relative '../../Path'
+require_relative '../Submodule'
+require_relative '../Utilities'
+require_relative '../../Logger'
+
+module WebBlocks
+  module Build
+    module Package
+      class Efx
+        
+        include ::WebBlocks::Logger
+        include ::WebBlocks::Path::Temporary_Build
+        include ::WebBlocks::Build::Submodule
+        include ::WebBlocks::Build::Utilities
+        
+        def preprocess
+          # call-forward
+          preprocess_js
+        end
+        
+        def preprocess_js
+          # git submodule init + update
+          preprocess_submodule :efx
+        end
+        
+        def assemble
+          # call-forward
+          assemble_js
+        end
+        
+        def assemble_js
+          
+          # initiate a task within logger scope
+          log.task "Package: Efx", "Copying Efx engine to JS build file" do
+            # append efx's src/engine.js file to tmp_js_build_file
+            file = "#{package_dir :efx}/src/engine.js"
+            log.debug "#{tmp_js_build_file.gsub /^#{root_dir}\//, ''} <<- #{file.gsub /^#{root_dir}\//, ''}"
+            append_file file, tmp_js_build_file
+          end
+          
+          # initiate a task within logger scope
+          log.task "Package: Efx", "Copying Efx drivers to CSS/JS build file" do
+            # append all files in efx's src/driver directory to tmp_js_build_file
+            dir = "#{package_dir :efx}/src/driver"
+            Dir.entries(dir).each do |file|
+              next if file[0,1] == '.'
+              src = "#{dir}/#{file}"
+              dst = false
+              if file.match /\.css$/
+                dst = tmp_css_build_file
+              elsif file.match /\.js$/
+                dst = tmp_js_build_file
+              end
+              log.debug "#{dst.gsub /^#{root_dir}\//, ''} <<- #{src.gsub /^#{root_dir}\//, ''}"
+              append_file src, dst if dst
+            end
+          end
+          
+        end
+        
+        def reset_package
+          # delete submodule contents
+          reset_submodule :efx
+        end
+        
+      end
+    end
+  end
+end</pre>
+
+<p>Package handlers have complete control over the way in which they load packages. The example of <code>efx</code> shows how a package handler can be used to roll up a larger set of assets rather than just a single file. Of course, in addition to doing this directly, a package handler also has the ability to invoke a compiler to build a package (if it comes equipped with its own compiler).</p>
+
+<h3>Package without Submodule</h3>
+
+<p>The above example showed how one can compile assets directly, and it suggested that one could also invoke a third-party compiler or other process to handle building the assets before appending them. However, in the case of <code>jquery</code>, the WebBlocks team has had some issues getting its <code>grunt</code> process to reliably create a build on all environments. Consequently, the <code>jquery</code> handler actually takes a totally different route: instead of using a submodule, during the compile step, it instead goes to the web and fetches a copy of the jQuery compiled source file.</p>
+
+<p>The <code>jquery</code> package handler may be found in <code>lib/Build/Package/Jquery.rb</code>:</p>
+
+<pre class="prettyprint">require 'rubygems'
+require 'extensions/kernel' if defined?(require_relative).nil?
+require 'net/http'
+require_relative '../../Path'
+require_relative '../Submodule'
+require_relative '../Utilities'
+require_relative '../../Logger'
+
+module WebBlocks
+  module Build
+    module Package
+      class Jquery
+        
+        def domain
+          'code.jquery.com'
+        end
+        
+        def path
+          config[:build][:debug] ? '/jquery-1.8.3.js' : '/jquery-1.8.3.min.js'
+        end
+        
+        include ::WebBlocks::Logger
+        include ::WebBlocks::Path::Temporary_Build
+        include ::WebBlocks::Build::Submodule
+        include ::WebBlocks::Build::Utilities
+        
+        def compile
+          # call-forward
+          compile_js
+        end
+        
+        def compile_js
+          # fetch a compiled version of jQuery
+          filename =  "#{package_dir :jquery}/dist/jquery.js"
+          unless File.exists? filename
+            # ensure that the --offline flag was not set
+            if ::WebBlocks.config[:options][:offline]
+              log.failure "Submodule", "Cannot download compiled version of jQuery in offline mode\nMust call rake the first time without --offline flag"
+            end
+            # initiate a task within logger scope
+            log.task "Package: jQuery", "Downloading compiled version of jQuery" do
+              # download a copy of jQuery and save it to the jQuery package dir
+              Net::HTTP.start(domain) do |http|
+                resp = http.get(path)
+                FileUtils.mkdir_p File.dirname(filename)
+                open(filename, "w") do |file|
+                  file.write(resp.body)
+                end
+              end
+            end
+          end
+        end
+        
+        def assemble
+          # call-forward
+          assemble_js
+        end
+        
+        def assemble_js
+          # initiate a task within logger scope
+          log.task "Package: jQuery", "Copying jQuery sources to JS build file" do
+            # append jQuery's jquery.js file to tmp_js_build_file
+            file = "#{package_dir :jquery}/dist/jquery.js"
+            log.debug "#{tmp_js_build_file.gsub /^#{root_dir}\//, ''} <<- #{file.gsub /^#{root_dir}\//, ''}"
+            append_file file, tmp_js_build_file
+          end
+        end
+        
+        def clean_package
+          # clear out the compiled version of jquery
+          FileUtils.rm_rf "#{package_dir :jquery}/dist" if File.exists? "#{package_dir :jquery}/dist"
+        end
+        
+        def reset_package
+          # delete submodule contents
+          reset_submodule :jquery
+        end
+        
+      end
+    end
+  end
+end</pre>
+
+<p>In this case, the package handler foregoes the traditional <code>preprocess</code> step, as it is going to instead fetch a copy of the jQuery sources from the web. Further, for semantic purposes, it uses the <code>compile</code> stage to actually retrieve the assets from the web, given that this simulates an actual compile of jQuery. The rest of the process is roughly synonymous to the earlier examples.</p>

--- a/doc/page/core/architecture/package.ejs
+++ b/doc/page/core/architecture/package.ejs
@@ -1,6 +1,6 @@
 <h2>Package</h2>
 
-<p>Pacakges provide a way to load in a third-party module. Traditionally, they are checked out as Git submodules, although WebBlocks leaves the exact mechanics for retrieving and maintaining the third-party code to the package handler.</p> 
+<p>Packages provide a way to load in a third-party module. Traditionally, they are checked out as Git submodules, although WebBlocks leaves the exact mechanics for retrieving and maintaining the third-party code to the package handler.</p> 
 
 <p><span class="badge warning">NOTE</span> This document assumes familiarity with the <a href="#Core/Architecture/Terminology">Terminology</a> and <a href="#Core/Architecture/Build">Build Process</a> sections.</p>
 

--- a/doc/page/core/contribute/model.ejs
+++ b/doc/page/core/contribute/model.ejs
@@ -1,0 +1,203 @@
+<h2>Contribution Model</h2>
+
+<p>WebBlocks is an open-source collaborative project that is the sum of its contributors. There are a number of different ways to get involved. At the most basic level, simply providing bug reports or proposing specifications for new features is something much appreciated. However, for those that want to go further, the WebBlocks core team is also more than happy to accept pull requests for features developed by users, so long as quality assurance is met.</p>
+
+<h3>Reporting a Bug</h3>
+
+<p>All bugs should be reported on the <a href="https://github.com/ucla/WebBlocks/issues" target="_blank">WebBlocks Issue Tracker</a>. When reporting a bug, the following should be provided:</p>
+
+<ol>
+    <li>Basic description of the issue</li>
+    <li>If non-obvious, an explanation as to why it's an issue</li>
+    <li>Any browser, OS or WebBlocks details that may relate</li>
+</ol>
+
+<p>If the bug relates to the compiler, before reporting the bug, please confirm that invoking <code>rake</code> on a clean copy of WebBlocks works and that all the tests pass by invoking <code>rake test</code>. If these fail, please refer to <a href="#Configuration/Troubleshoot" target="_blank">Troubleshooting</a>; if your issue is not listed there, then feel free to report it as such.</p>
+
+<h3>Proposing a Feature</h3>
+
+<p>All feature proposals should start by creating an issue on the <a href="https://github.com/ucla/WebBlocks/issues" target="_blank">WebBlocks Issue Tracker</a>. Within the issue, also provide a description with the following:</p>
+
+<ul>
+    <li>Basic description of the feature</li>
+    <li>Motivation and/or usages</li>
+    <li>Specific features and options</li>
+    <li>Any pertinent edge cases (such as responsive considerations for new elements)</li>
+</ul>
+
+<p>When proposing a new element, we ask that a generic template of the entity ("prototype") be provided for the feature, adhering to the following standards:</p>
+
+<ul>
+    <li>Only include the HTML required for the element (do not include the html element, for example)</li>
+    <li>Use HTML comments before an element to specify multiplicity (how many of an element)</li>
+    <li>Use the pipe/or (|) character to signify multiple possible values</li>
+    <li>Replace parameterized values with a description enclosed in curly brackets ({})</li>
+    <li>Include additional comments for further explanation</li>
+</ul>
+
+<p>For example, here's a possible prototype for the gallery entity:</p>
+
+<pre class="prettyprint">&lt;figure&gt;
+  &lt;!-- 1..* --&gt;
+  &lt;ul|ol class="gallery"&gt;
+    &lt;!-- 1..* --&gt;
+      &lt;li&gt;
+        &lt;!-- 1 --&gt;
+          &lt;a href="{Image 1 URL}"&gt;
+        &lt;img src="{Image 1 Thumbnail URL}" alt="{Image 1 Alt Text}" /&gt;
+      &lt;/a&gt;
+    &lt;/li&gt;
+  &lt;/ul&gt;
+&lt;/figure&gt;</pre>
+
+<p>When specifying multiplicity, use the following guide:</p>
+
+<ul>
+    <li><code>0</code> zero exactly</li>
+    <li><code>0..1</code> zero or one</li>
+    <li><code>0..*</code> zero or more</li>
+    <li><code>1..*</code> one or more</li>
+    <li><code>1</code> one exactly</li>
+</ul>
+
+<p>To reference another Web Blocks component from within a prototype, use the following syntax:</p>
+
+<pre class="prettyprint">&lt;!-- [[ComponentName]] --&gt;</pre>
+
+<p>For example, if you were referencing <code>Entity/Blockquote</code> from within another prototype:</p>
+
+<pre class="prettyprint">&lt;div class="example-component"&gt;
+	
+	&lt;!-- 0..1 --&gt;
+	&lt;!-- [[Entity/Nav/Blockquote]] --&gt;
+
+&lt;/div&gt;</pre>
+
+<p>Once the issue is up on GitHub, it will undergo discussion. If you're satisfied with the outcome of the discussion and willing to implement the change, volunteering is appreciated. However, otherwise it will be moved into a queue based on the varying priorities of other open issues.</p>
+
+<h3>Contributing Code</h3>
+
+<p>WebBlocks uses a version of the <strong>pull request model</strong> for all code submissions. Summarized briefly, the process is roughly as follows:</p>
+
+<ol class="list upper-roman">
+    <li>Fork WebBlocks.</li>
+    <li>Create an issue on the WebBlocks issue tracker, whereby:
+        <ol class="list lower-roman">
+            <li>If the issue is a bug, explain what caused the bug.</li>
+            <li>If the issue is a new feature, explain the motivation for it.</li>
+        </ol>
+    </li>
+    <li>Create a branch on your fork with commits to address the issue.</li>
+    <li>Issue a pull request from the branch when it's done, including:
+        <ol class="list lower-roman">
+            <li>Code changes necessary to resolve the issue.</li>
+            <li>Additions/updates to the documentation for the change.</li>
+            <li>If the code modifies the compiler, unit tests for the change.</li>
+        </ol>
+    </li>
+    <li>The pull request will be reviewed, including:
+        <ol class="list lower-roman">
+            <li>Review of the code, documentation and tests.</li>
+            <li>Unit and build tests must pass.</li>
+        </ol>
+    </li>
+    <li>If everything checks out, the pull request will be merged by an integration manager.</li>
+</ol>
+
+<h4>Forking WebBlocks</h4>
+
+<p>The first step for contributing is to create a fork of WebBlocks. This can be done by going to the <a href="https://github.com/ucla/WebBlocks">WebBlocks Repository</a> on GitHub, while logged in, and pressing the "Fork" button</p>
+
+<p>Once you have your fork set up, you need to clone it as a local repository on your computer:</p>
+
+<pre>git clone https://[ACCOUNT-NAME]@github.com/[ACCOUNT-NAME]/WebBlocks.git [DIRECTORY-NAME]</pre>
+
+<p>This will automatically set up a remote called <code>origin</code> that refers to the repository that you cloned and checks out the default branch (usually master).</p>
+
+<p>Because this is a fork of the canonical repository, you need to make sure that you can also pull commits from that repository as well. As such, you should establish a second remote:</p>
+
+<pre>git remote add upstream https://[ACCOUNT-NAME]@github.com/ucla/WebBlocks.git</pre>
+
+<p>To update the <code>master</code> branch on your fork to the latest version of WebBlocks:</p>
+
+<pre>git checkout master
+git pull upstream master</pre>
+
+<p>When you do this, you should also make sure to update your remote:</p>
+
+<pre>git push upstream master</pre>
+
+<h4>Detailing the Feature</h4>
+
+<p>The WebBlocks contribution process requires that any feature being contributed <strong>must</strong> have a ticket first created for it in the <a href="https://github.com/ucla/WebBlocks/issues" target="_blank">WebBlocks Issue Tracker</a>. This ensures that discussion on an issue begins <em>early</em> in the process. Please refer to earlier sections regarding details that should be provided in an issue relating to a bug or new feature.</p>
+
+<h4>Developing the Feature</h4>
+
+<p>While <code>master</code> is where you update to the latest version of WebBlocks, it is not recommended that you develop any contributions on <code>master</code>. Instead, whenever working on a feature, it should be created on it's own branch such that you can issue a pull request on the branch to submit that change back to the WebBlocks project.</p>
+
+<p>Before starting a branch, ensure that your <code>master</code> branch is up to date:</p>
+
+<pre>git checkout master             # switch to the master branch
+git pull origin master          # for good measure as this should already align with origin
+git pull upstream master        # to fetch the latest set of changes from the canonical remote
+git push origin master          # update the remote fork with the latest changes from the canonical remote</pre>
+
+<p>Then, to create a new branch, issue:</p>
+
+<pre>git checkout -b [BRANCH-NAME] master</pre>
+
+<p>This command says to create a new branch named <code>[BRANCH-NAME]</code> that starts out identical to the <code>master</code> branch. For organization, the WebBlocks team recommends using <code>fix/[ISSUE-NUM]</code> or <code>feature/[ISSUE-NUM]</code> for your branch names, to make it easy to determine what issue the branch relates to, but this is not required.</p>
+
+<p>Once you've got a branch, you can start making changes. Simply edit files as usual and test on your local copy. When you're ready to designate a file to be committed, you need to add the files:
+
+<pre>git add [FILE-NAME]</pre>
+
+<p>This command will add files to a staging area to wait for commit. Files in this staging area are not monitored for changes. If you change the file, you must run the command again to add the changes.</p>
+
+<p>The <code>[FILE-NAME]</code> value can be a file or directory. Further, if you use * as the file name, then you will add all changed files in your local copy. Use this with caution if you have configuration files that are not in your <code>.gitignore</code> file. You can also specify multiple files/directories as a set of space-separated paths. All paths are local to your current working directory.</p>
+
+<p>When you've got all files added for a commit, issue the following:</p>
+
+<pre>git commit -m "#[ISSUE-NUM] - [COMMIT-MESSAGE]"</pre>
+
+<p>The first segment of the commit message (before the hyphen) is used to "link" the commit to an issue on GitHub. For instance, if a commit related to issue #200, then the commit message would be:</p>
+
+<pre>git commit -m "#200 - [COMMIT-MESSAGE]"</pre>
+
+<p>The [COMMIT-MESSAGE] should have a first line that is 60 characters or less in length. If your commit has additional details, enter an empty line and then additional lines, each no more than 72 characters in length. This is to ensure proper formatting when viewing commits in GitHub and through the terminal.</p>
+
+<p>A long commit message might be as follows:</p>
+
+<pre>git commit -m "[SHORT-DESCRIPTION]
+
+[LONGER-DESCRIPTION...
+...
+...]"</pre>
+
+<h4>Contributing the Feature</h4>
+
+<p>Once you've done the necessary commits and you're ready to contribute the branch containing the feature, you need to expose it through your remote fork:</p>
+
+<pre>git push origin [BRANCH-NAME]</pre>
+
+<p>It is common during development on a branch to push multiple times. This ensures that your collaborators can see what you're working on and also that you've got a remote backup in case your local copy is somehow rendered inoperable. However, this guide is simply exploring the minimal case.</p>
+
+<p>With the branch now in your remote fork, you can issue a pull request to WebBlocks for it:</p>
+
+<ol>
+    <li>Go to your remote fork on GitHub</li>
+    <li>Select your branch from the dropdown to the left of the "Files" tab</li>
+    <li>Press the "Pull Request" button</li>
+    <li>Ensure that the proper branches and repositories are selected</li>
+    <li>Enter details about the pull request and assign it to the integration manager</li>
+</ol>
+
+<p>In the description for the pull request, please include:</p>
+
+<ul>
+    <li>Code changes necessary to resolve the issue.</li>
+    <li>Additions/updates to the documentation for the change.</li>
+    <li>If the code modifies the compiler, unit tests for the change.</li>
+</ul>
+
+<p>The pull request will then be reviewed, meaning a thorough review of the code, documentation and tests. Interested parties are encouraged to weigh in both during the initial creation of the issue and during the pull request review stage. Any issues found may require additional work on the branch, which should then be pushed up to the remote fork (and will be automatically reflected in the pull request). Once any issues from the review are resolved, and the unit and build tests pass, then pull request will then be merged into the canonical <code>master</code> and the issue closed.</p>

--- a/doc/page/core/contribute/model.ejs
+++ b/doc/page/core/contribute/model.ejs
@@ -1,6 +1,10 @@
 <h2>Contribution Model</h2>
 
-<p>WebBlocks is an open-source collaborative project that is the sum of its contributors. There are a number of different ways to get involved. At the most basic level, simply providing bug reports or proposing specifications for new features is something much appreciated. However, for those that want to go further, the WebBlocks core team is also more than happy to accept pull requests for features developed by users, so long as quality assurance is met.</p>
+<p>WebBlocks is an open-source collaborative project that is the sum of its contributors. There are a number of different ways to get involved.</p>
+
+<p>At the most basic level, simply providing bug reports or proposing specifications for new features is something much appreciated. Any feedback on open issues or pull requests can also help ensure that bugs are addressed expediently and new features meet with user needs.</p>
+
+<p>For those so inclined, the WebBlocks core team highly encourages developer to submit pull requests for bug fixes and features that impact them.</p>
 
 <h3>Reporting a Bug</h3>
 
@@ -104,100 +108,4 @@
     <li>If everything checks out, the pull request will be merged by an integration manager.</li>
 </ol>
 
-<h4>Forking WebBlocks</h4>
-
-<p>The first step for contributing is to create a fork of WebBlocks. This can be done by going to the <a href="https://github.com/ucla/WebBlocks">WebBlocks Repository</a> on GitHub, while logged in, and pressing the "Fork" button</p>
-
-<p>Once you have your fork set up, you need to clone it as a local repository on your computer:</p>
-
-<pre>git clone https://[ACCOUNT-NAME]@github.com/[ACCOUNT-NAME]/WebBlocks.git [DIRECTORY-NAME]</pre>
-
-<p>This will automatically set up a remote called <code>origin</code> that refers to the repository that you cloned and checks out the default branch (usually master).</p>
-
-<p>Because this is a fork of the canonical repository, you need to make sure that you can also pull commits from that repository as well. As such, you should establish a second remote:</p>
-
-<pre>git remote add upstream https://[ACCOUNT-NAME]@github.com/ucla/WebBlocks.git</pre>
-
-<p>To update the <code>master</code> branch on your fork to the latest version of WebBlocks:</p>
-
-<pre>git checkout master
-git pull upstream master</pre>
-
-<p>When you do this, you should also make sure to update your remote:</p>
-
-<pre>git push upstream master</pre>
-
-<h4>Detailing the Feature</h4>
-
-<p>The WebBlocks contribution process requires that any feature being contributed <strong>must</strong> have a ticket first created for it in the <a href="https://github.com/ucla/WebBlocks/issues" target="_blank">WebBlocks Issue Tracker</a>. This ensures that discussion on an issue begins <em>early</em> in the process. Please refer to earlier sections regarding details that should be provided in an issue relating to a bug or new feature.</p>
-
-<h4>Developing the Feature</h4>
-
-<p>While <code>master</code> is where you update to the latest version of WebBlocks, it is not recommended that you develop any contributions on <code>master</code>. Instead, whenever working on a feature, it should be created on it's own branch such that you can issue a pull request on the branch to submit that change back to the WebBlocks project.</p>
-
-<p>Before starting a branch, ensure that your <code>master</code> branch is up to date:</p>
-
-<pre>git checkout master             # switch to the master branch
-git pull origin master          # for good measure as this should already align with origin
-git pull upstream master        # to fetch the latest set of changes from the canonical remote
-git push origin master          # update the remote fork with the latest changes from the canonical remote</pre>
-
-<p>Then, to create a new branch, issue:</p>
-
-<pre>git checkout -b [BRANCH-NAME] master</pre>
-
-<p>This command says to create a new branch named <code>[BRANCH-NAME]</code> that starts out identical to the <code>master</code> branch. For organization, the WebBlocks team recommends using <code>fix/[ISSUE-NUM]</code> or <code>feature/[ISSUE-NUM]</code> for your branch names, to make it easy to determine what issue the branch relates to, but this is not required.</p>
-
-<p>Once you've got a branch, you can start making changes. Simply edit files as usual and test on your local copy. When you're ready to designate a file to be committed, you need to add the files:
-
-<pre>git add [FILE-NAME]</pre>
-
-<p>This command will add files to a staging area to wait for commit. Files in this staging area are not monitored for changes. If you change the file, you must run the command again to add the changes.</p>
-
-<p>The <code>[FILE-NAME]</code> value can be a file or directory. Further, if you use * as the file name, then you will add all changed files in your local copy. Use this with caution if you have configuration files that are not in your <code>.gitignore</code> file. You can also specify multiple files/directories as a set of space-separated paths. All paths are local to your current working directory.</p>
-
-<p>When you've got all files added for a commit, issue the following:</p>
-
-<pre>git commit -m "#[ISSUE-NUM] - [COMMIT-MESSAGE]"</pre>
-
-<p>The first segment of the commit message (before the hyphen) is used to "link" the commit to an issue on GitHub. For instance, if a commit related to issue #200, then the commit message would be:</p>
-
-<pre>git commit -m "#200 - [COMMIT-MESSAGE]"</pre>
-
-<p>The [COMMIT-MESSAGE] should have a first line that is 60 characters or less in length. If your commit has additional details, enter an empty line and then additional lines, each no more than 72 characters in length. This is to ensure proper formatting when viewing commits in GitHub and through the terminal.</p>
-
-<p>A long commit message might be as follows:</p>
-
-<pre>git commit -m "[SHORT-DESCRIPTION]
-
-[LONGER-DESCRIPTION...
-...
-...]"</pre>
-
-<h4>Contributing the Feature</h4>
-
-<p>Once you've done the necessary commits and you're ready to contribute the branch containing the feature, you need to expose it through your remote fork:</p>
-
-<pre>git push origin [BRANCH-NAME]</pre>
-
-<p>It is common during development on a branch to push multiple times. This ensures that your collaborators can see what you're working on and also that you've got a remote backup in case your local copy is somehow rendered inoperable. However, this guide is simply exploring the minimal case.</p>
-
-<p>With the branch now in your remote fork, you can issue a pull request to WebBlocks for it:</p>
-
-<ol>
-    <li>Go to your remote fork on GitHub</li>
-    <li>Select your branch from the dropdown to the left of the "Files" tab</li>
-    <li>Press the "Pull Request" button</li>
-    <li>Ensure that the proper branches and repositories are selected</li>
-    <li>Enter details about the pull request and assign it to the integration manager</li>
-</ol>
-
-<p>In the description for the pull request, please include:</p>
-
-<ul>
-    <li>Code changes necessary to resolve the issue.</li>
-    <li>Additions/updates to the documentation for the change.</li>
-    <li>If the code modifies the compiler, unit tests for the change.</li>
-</ul>
-
-<p>The pull request will then be reviewed, meaning a thorough review of the code, documentation and tests. Interested parties are encouraged to weigh in both during the initial creation of the issue and during the pull request review stage. Any issues found may require additional work on the branch, which should then be pushed up to the remote fork (and will be automatically reflected in the pull request). Once any issues from the review are resolved, and the unit and build tests pass, then pull request will then be merged into the canonical <code>master</code> and the issue closed.</p>
+<p>Details around the mechanics of code contribution may be found in <a href="#Core/Contribute/Submit">Submission Process</a>.</p>

--- a/doc/page/core/contribute/submit.ejs
+++ b/doc/page/core/contribute/submit.ejs
@@ -1,0 +1,101 @@
+<h2>Submission Process</h2>
+
+<p>This document details the submission process for contributing fixes and new features to WebBlocks through the <strong>pull request model</strong>. For an overview of the contribution process, please see <a href="#Core/Contribute/Model">Contribution Model</a>.
+
+<h3>Forking WebBlocks</h3>
+
+<p>The first step for contributing is to create a fork of WebBlocks. This can be done by going to the <a href="https://github.com/ucla/WebBlocks">WebBlocks Repository</a> on GitHub, while logged in, and pressing the "Fork" button</p>
+
+<p>Once you have your fork set up, you need to clone it as a local repository on your computer:</p>
+
+<pre>git clone https://[ACCOUNT-NAME]@github.com/[ACCOUNT-NAME]/WebBlocks.git [DIRECTORY-NAME]</pre>
+
+<p>This will automatically set up a remote called <code>origin</code> that refers to the repository that you cloned and checks out the default branch (usually master).</p>
+
+<p>Because this is a fork of the canonical repository, you need to make sure that you can also pull commits from that repository as well. As such, you should establish a second remote:</p>
+
+<pre>git remote add upstream https://[ACCOUNT-NAME]@github.com/ucla/WebBlocks.git</pre>
+
+<p>To update the <code>master</code> branch on your fork to the latest version of WebBlocks:</p>
+
+<pre>git checkout master
+git pull upstream master</pre>
+
+<p>When you do this, you should also make sure to update your remote:</p>
+
+<pre>git push upstream master</pre>
+
+<h3>Detailing the Feature</h3>
+
+<p>The WebBlocks contribution process requires that any feature being contributed <strong>must</strong> have a ticket first created for it in the <a href="https://github.com/ucla/WebBlocks/issues" target="_blank">WebBlocks Issue Tracker</a>. This ensures that discussion on an issue begins <em>early</em> in the process. Please refer to earlier sections regarding details that should be provided in an issue relating to a bug or new feature.</p>
+
+<h3>Developing the Feature</h3>
+
+<p>While <code>master</code> is where you update to the latest version of WebBlocks, it is not recommended that you develop any contributions on <code>master</code>. Instead, whenever working on a feature, it should be created on it's own branch such that you can issue a pull request on the branch to submit that change back to the WebBlocks project.</p>
+
+<p>Before starting a branch, ensure that your <code>master</code> branch is up to date:</p>
+
+<pre>git checkout master             # switch to the master branch
+git pull origin master          # for good measure as this should already align with origin
+git pull upstream master        # to fetch the latest set of changes from the canonical remote
+git push origin master          # update the remote fork with the latest changes from the canonical remote</pre>
+
+<p>Then, to create a new branch, issue:</p>
+
+<pre>git checkout -b [BRANCH-NAME] master</pre>
+
+<p>This command says to create a new branch named <code>[BRANCH-NAME]</code> that starts out identical to the <code>master</code> branch. For organization, the WebBlocks team recommends using <code>fix/[ISSUE-NUM]</code> or <code>feature/[ISSUE-NUM]</code> for your branch names, to make it easy to determine what issue the branch relates to, but this is not required.</p>
+
+<p>Once you've got a branch, you can start making changes. Simply edit files as usual and test on your local copy. When you're ready to designate a file to be committed, you need to add the files:
+
+<pre>git add [FILE-NAME]</pre>
+
+<p>This command will add files to a staging area to wait for commit. Files in this staging area are not monitored for changes. If you change the file, you must run the command again to add the changes.</p>
+
+<p>The <code>[FILE-NAME]</code> value can be a file or directory. Further, if you use * as the file name, then you will add all changed files in your local copy. Use this with caution if you have configuration files that are not in your <code>.gitignore</code> file. You can also specify multiple files/directories as a set of space-separated paths. All paths are local to your current working directory.</p>
+
+<p>When you've got all files added for a commit, issue the following:</p>
+
+<pre>git commit -m "#[ISSUE-NUM] - [COMMIT-MESSAGE]"</pre>
+
+<p>The first segment of the commit message (before the hyphen) is used to "link" the commit to an issue on GitHub. For instance, if a commit related to issue #200, then the commit message would be:</p>
+
+<pre>git commit -m "#200 - [COMMIT-MESSAGE]"</pre>
+
+<p>The [COMMIT-MESSAGE] should have a first line that is 60 characters or less in length. If your commit has additional details, enter an empty line and then additional lines, each no more than 72 characters in length. This is to ensure proper formatting when viewing commits in GitHub and through the terminal.</p>
+
+<p>A long commit message might be as follows:</p>
+
+<pre>git commit -m "[SHORT-DESCRIPTION]
+
+[LONGER-DESCRIPTION...
+...
+...]"</pre>
+
+<h3>Contributing the Feature</h3>
+
+<p>Once you've done the necessary commits and you're ready to contribute the branch containing the feature, you need to expose it through your remote fork:</p>
+
+<pre>git push origin [BRANCH-NAME]</pre>
+
+<p>It is common during development on a branch to push multiple times. This ensures that your collaborators can see what you're working on and also that you've got a remote backup in case your local copy is somehow rendered inoperable. However, this guide is simply exploring the minimal case.</p>
+
+<p>With the branch now in your remote fork, you can issue a pull request to WebBlocks for it:</p>
+
+<ol>
+    <li>Go to your remote fork on GitHub</li>
+    <li>Select your branch from the dropdown to the left of the "Files" tab</li>
+    <li>Press the "Pull Request" button</li>
+    <li>Ensure that the proper branches and repositories are selected</li>
+    <li>Enter details about the pull request and assign it to the integration manager</li>
+</ol>
+
+<p>In the description for the pull request, please include:</p>
+
+<ul>
+    <li>Code changes necessary to resolve the issue.</li>
+    <li>Additions/updates to the documentation for the change.</li>
+    <li>If the code modifies the compiler, unit tests for the change.</li>
+</ul>
+
+<p>The pull request will then be reviewed, meaning a thorough review of the code, documentation and tests. Interested parties are encouraged to weigh in both during the initial creation of the issue and during the pull request review stage. Any issues found may require additional work on the branch, which should then be pushed up to the remote fork (and will be automatically reflected in the pull request). Once any issues from the review are resolved, and the unit and build tests pass, then pull request will then be merged into the canonical <code>master</code> and the issue closed.</p>


### PR DESCRIPTION
Revisions to Configuration/Overview and Compiler/Sources for #319.

Added compiler flags and cleaned up task documentation in #309.

Add links for package documentation for #330.

Added new pages for Core/Architecture/Module, Core/Architecture/Package, Core/Architecture/Adapter, Core/Contribute/Model and Core/Contribute/Submit for #289.
