### PR TITLE
Fix #396 - Add support for CSS splitting

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "package/lettering"]
 	path = package/lettering
 	url = https://github.com/davatron5000/Lettering.js.git
+[submodule "package/OptiCSS"]
+	path = package/OptiCSS
+	url = https://github.com/ebollens/OptiCSS.git

--- a/lib/Build/Package/Opticss.rb
+++ b/lib/Build/Package/Opticss.rb
@@ -1,0 +1,139 @@
+require 'rubygems'
+require 'fileutils'
+require 'extensions/kernel' if defined?(require_relative).nil?
+require_relative '../../Path'
+require_relative '../Submodule'
+require_relative '../Utilities'
+require_relative '../../Logger'
+
+module WebBlocks
+  
+  module Build
+    
+    module Package
+      
+      class Opticss
+        
+        include ::WebBlocks::Logger
+        include ::WebBlocks::Path::Build
+        include ::WebBlocks::Path::Temporary_Build
+        include ::WebBlocks::Build::Submodule
+        include ::WebBlocks::Build::Utilities
+        
+        def preprocess
+          
+          preprocess_css
+          
+        end
+        
+        def preprocess_css
+          
+          if config[:build][:debug]
+            log.warning "Package: OptiCSS", "Skipping OptiCSS because in debug mode"
+            return
+          end
+          
+          preprocess_submodule :opticss
+          preprocess_submodule_submodules :opticss
+          
+        end
+        
+        def postprocess
+          
+          postprocess_css
+          
+        end
+        
+        def postprocess_css
+          
+          if config[:build][:debug]
+            log.warning "Package: OptiCSS", "Skipping OptiCSS because in debug mode"
+            return
+          end
+            
+          with_clean_bundler_env do
+              
+            opticss_package_dir = package_dir :opticss
+
+            log.task "Package: OptiCSS", "Installing OptiCSS dependencies via Bundler" do
+              status, stdout, stderr = systemu "#{config[:exec][:bundler]} --gemfile \"#{opticss_package_dir}/Gemfile\""
+              if stderr.length > 0
+                log.failure "Package: OptiCSS", "Bundler failed to complete successfully"
+              end
+            end
+            
+            tmp_file_path = from_tmp_build_dir_to "opticss.rb"
+            
+            [
+              {:build_file => css_build_file, :commands => config[:package][:opticss][:commands]},
+              {:build_file => css_build_file_ie, :commands => config[:package][:opticss][:commands_ie]}
+            ].each do |run|
+              
+              log.task "Package: OptiCSS", "Running OptiCSS for #{run[:build_file]}" do
+              
+                File.open(tmp_file_path, "w") do |io| 
+                  commands = run[:commands]
+                  commands.gsub! /\[\[save_file\]\]/, "\'#{run[:build_file]}\'"
+                  io.write commands
+                end
+
+                cmd = "require 'rubygems'
+  require '#{package_dir :opticss}/lib/Optimizer'
+  OptiCSS::Optimizer.new \"#{run[:build_file]}\" do
+    eval File.open(\"#{tmp_file_path}\") {|f| f.read }
+  end".gsub("\"", "\\\"")
+
+                status, stdout, stderr = systemu "ruby -e \"#{cmd.sub("\\", "\\\\")}\""
+
+                if stderr.length > 0
+                  log.failure "OptiCSS run failed" do
+                    log.debug stderr
+                  end
+                else
+                  log.info "OptiCSS ran successfully" do
+                    log.debug run[:commands]
+                  end
+                end
+              
+              end
+              
+            end
+            
+          end
+          
+        end
+        
+        def clean
+          
+          log.task "Package: OptiCSS", "Removing build split_save products" do
+          
+            [css_build_file, css_build_file_ie].each do |file|
+              dir = File.dirname file
+              Dir.foreach(dir) do |item|
+                next if item == '.' or item == '..'
+                base = File.basename(file).gsub(/\.css$/, "")
+                if !!item.match(/#{base}\-\d*\.css$/)
+                  log.info "Removed #{dir}/#{item}" do
+                    FileUtils.rm_rf "#{dir}/#{item}"
+                  end
+                end
+              end
+            end
+          
+          end
+          
+        end
+        
+        def reset_package
+          
+          reset_submodule :opticss
+          
+        end
+        
+      end
+      
+    end
+    
+  end
+  
+end

--- a/lib/Build/Submodule.rb
+++ b/lib/Build/Submodule.rb
@@ -42,22 +42,22 @@ module WebBlocks
       def init_submodule_submodules name
         
         if ::WebBlocks.config[:options][:offline]
-          log.info "Submodule", "Skipped updating submodules of submodule #{name} (offline mode)"
+          log.info "Submodule", "Skipped initializing submodules of submodule #{name} (offline mode)"
           return
         end
         
         stdout = ""
         
-        log.task "Submodule", "Updating submodules of submodule #{name}" do
+        log.task "Submodule", "Initializing submodules of submodule #{name}" do
         
           Dir.chdir(package_dir name) do
           
-            status, stdout, stderr = systemu "#{config[:exec][:git]} submodule update"
+            status, stdout, stderr = systemu "#{config[:exec][:git]} submodule init"
 
             if stderr.length > 0
-              log.failure "Submodule: #{name}", "Update failed for submodules of submodule #{name}"
+              log.failure "Submodule: #{name}", "Initialization failed for submodules of submodule #{name}"
             else
-              log.info "Submodule: #{name}", "Updated submodules of submodule #{name}"
+              log.info "Submodule: #{name}", "Initialized submodules of submodule #{name}"
             end
           
           end

--- a/lib/Build/Utilities.rb
+++ b/lib/Build/Utilities.rb
@@ -80,6 +80,15 @@ module WebBlocks
         end
         files
       end
+        
+      BUNDLER_VARS = %w(BUNDLE_GEMFILE RUBYOPT BUNDLE_BIN_PATH)
+      def with_clean_bundler_env
+        bundled_env = ENV.to_hash
+        BUNDLER_VARS.each{ |var| ENV.delete(var) }
+        yield
+      ensure
+        ENV.replace(bundled_env.to_hash)
+      end
       
     end
     

--- a/lib/Build/WebBlocks.rb
+++ b/lib/Build/WebBlocks.rb
@@ -352,8 +352,10 @@ module WebBlocks
           
           files = [css_build_file, css_build_file_ie, js_build_file, js_build_file_ie]
           files.each do |file|
-            log.info "Removed #{file}" do
-              FileUtils.rm_rf file
+            if file and File.exists? file
+              log.info "Removed #{file}" do
+                FileUtils.rm_rf file
+              end
             end
           end
           

--- a/lib/Config.rb
+++ b/lib/Config.rb
@@ -97,7 +97,8 @@ module WebBlocks
     :modernizr,
     :respond,
     :selectivizr,
-    :efx
+    :efx,
+  # :opticss, # experimental: use with caution
   ]
   
   # src configuration
@@ -169,7 +170,8 @@ module WebBlocks
     :sass       => 'sass',
     :uglifycss  => 'node ./node_modules/uglifycss/uglifycss',
     :uglifyjs   => 'node ./node_modules/uglify-js/bin/uglifyjs',
-    :compass    => 'compass'
+    :compass    => 'compass',
+    :bundler    => 'bundle'
   }
   
   # package configuration
@@ -210,6 +212,12 @@ module WebBlocks
   
   @config[:package][:selectivizr] = {
     :dir      => 'selectivizr'
+  }
+  
+  @config[:package][:opticss] = {
+    :dir         => 'opticss',
+    :commands    => "split_save [[save_file]]",
+    :commands_ie => "split_save [[save_file]]"
   }
 
   # advanced configuration


### PR DESCRIPTION
Internet Explorer up through version 9 has a problem whereby it does not allow more than 4095 selectors per stylesheet.

One spitter implementation was proposed here:
https://gist.github.com/ChristianPeters/1131536

This has made it back into Rails here:
https://github.com/zweilove/css_splitter

Unfortunately, it is very primitive in the way it regards CSS. It does not know how to account for `@media` statements, simply splitting based on the `}` character. Initially, I tried to come up with a way to expand on their implementation: track `@media` scope and, when 4095 selectors are reached, close all open scopes, spin up a new file, and open all those scopes again; however, the CSS grammar is a bit rough, and so I decided better would be to leverage the existing structure of the OptiCSS project that I was working on for CSS optimization (has the parser and a DSL, although none of the actual optimization strategies were ever completed).

To this end, this pull request adds OptiCSS and defines the following rule:

``` ruby
split_save [[save_file]]
```

The `[[save_file]]` block is replaced by the actual file name. By changing properties under `WebBlocks.config[:package][:opticss]`, one can actually add additional commands as well, although I don't likely see a use for this yet as OptiCSS has never had any optimization strategies completed. Still, it's incredibly useful for this case.

However, because of the experimental nature of OptiCSS, I have _not_ made this a default package. Instead, if one wants to run with OptiCSS, they must add the following line to `Rakefile-config.rb`:

``` ruby
WebBlocks.config[:build][:packages] << :opticss unless WebBlocks.config[:build][:packages].include? :opticss
```

Once this is enabled, as long as debug mode is _not_ set to true, the sheets will be split and an aggregate sheet will be generated for `blocks[-ie].css` (in the event that the split produces more than one sheet - if it does a single sheet, then sheet is not chucked). Note that if debug mode is on, then OptiCSS will not run.

A few advantages garnered by this approach over the old one:
- Accounts for `@media` rules
- Does not cap out at 8190 rules after two files
- Generates a synthesis file of `@import` rules
