### PR TITLE
Shown logger warnings and errors in stdout [v1.0]

### DIFF
--- a/lib/Logger.rb
+++ b/lib/Logger.rb
@@ -24,7 +24,7 @@ module WebBlocks
         if ::WebBlocks.config[:options][:details]
           @types_to_print = [:system, :task, :failure, :success, :warning]
         else
-          @types_to_print = [:system]
+          @types_to_print = [:system, :failure, :warning]
         end
         @types_to_file = [:system, :task, :failure, :success, :warning, :info, :debug]
       end


### PR DESCRIPTION
Warnings and errors are ending up only in `build.log`. I'm not a fan of this - we should be exposing them as much as possible, even if the rest of our output is usually suppressed into `build.log` only.
