### PR TITLE
Fix #185 - Add :adaptiveimages package

### DIFF
--- a/doc/component/menu/api.ejs
+++ b/doc/component/menu/api.ejs
@@ -62,6 +62,8 @@
                 <br><small class="text-neutral"><code>:srcset</code></small></a></li>
         <li><a href="#API/Package/httpclienthints">HTTP Client Hints
                 <br><small class="text-neutral"><code>:httpclienthints</code></small></a></li>
+        <li><a href="#API/Package/adaptiveimages">Adaptive Images
+                <br><small class="text-neutral"><code>:adaptiveimages</code></small></a></li>
         <li><a href="#API/Package/fitvids">Flexible Video
                 <br><small class="text-neutral"><code>:fitvids</code></small></a></li>
         <li><a href="#API/Package/ie7imagescaling">IE < 8 Image Scaling

--- a/doc/page/api/package/adaptiveimages.ejs
+++ b/doc/page/api/package/adaptiveimages.ejs
@@ -1,0 +1,31 @@
+<h2>Package: Adaptive Images</h2>
+
+<p><a href="http://adaptive-images.com/" target="_blank">Adaptive Images</a> is a server-side script that compresses images based on client-size dimensions set in a cookie. The client-side cookie can be incorporated by including the <code>:adaptiveimages</code> package, or alternatively one may use <code>:httpclienthints</code> with a <a href="https://github.com/ebollens/Adaptive-Images" target="_blank">fork of Adaptive Images</a> capable of reading that cookie or the HTTP setting.</p>
+
+<h3>Using Directly</h3>
+
+<p>If using Adaptive Images directly, the Javascript component that writes the cookie may be added as:</p>
+
+<pre class="prettyprint">WebBlocks.config[:build][:packages] << :adaptiveimages</pre>
+
+<p>By default, this package will compress images at higher quality when the device in question has a high pixel density screen; however, this comes at the cost of larger images for high pixel density screens, and it may be disabled as:</p>
+
+<pre class="prettyprint">WebBlocks.config[:package][:adaptiveimages][:pixel_density] = false</pre>
+
+<p>This package is not included by default.</p>
+
+<h3>Using Client Hints</h3>
+
+<p>Alternatively, one may use HTTP Client Hints with Adaptive Images.</p>
+
+<p>To do this, pull the following fork of Adaptive Images:</p>
+
+<ul>
+    <li><a href="https://github.com/ebollens/Adaptive-Images" target="_blank">https://github.com/ebollens/Adaptive-Images</a></li>
+</ul>
+
+<p>Using this fork, the <code>:adaptiveimages</code> package <em>is not</em> needed. Instead, simply make sure that the HTTP Client Hints package is included:</p>
+
+<pre class='prettyprint'>WebBlocks.config[:build][:packages] << :httpclienthints</pre>
+
+<p>This package is not included by default.</p>

--- a/lib/Build/Package/Adaptiveimages.rb
+++ b/lib/Build/Package/Adaptiveimages.rb
@@ -37,12 +37,6 @@ module WebBlocks
           
         end
         
-        def reset_package
-          
-          reset_submodule :respond
-          
-        end
-        
       end
       
     end

--- a/lib/Build/Package/Adaptiveimages.rb
+++ b/lib/Build/Package/Adaptiveimages.rb
@@ -1,0 +1,52 @@
+require 'rubygems'
+require 'extensions/kernel' if defined?(require_relative).nil?
+require_relative '../../Path'
+require_relative '../Submodule'
+require_relative '../Utilities'
+require_relative '../../Logger'
+
+module WebBlocks
+  
+  module Build
+    
+    module Package
+      
+      class Adaptiveimages
+        
+        include ::WebBlocks::Logger
+        include ::WebBlocks::Path::Temporary_Build
+        include ::WebBlocks::Build::Submodule
+        include ::WebBlocks::Build::Utilities
+        
+        def assemble
+          
+          assemble_js
+          
+        end
+        
+        def assemble_js
+          
+          log.task "Package: AdaptiveImages", "Add Adaptive Images hook to JS build file" do
+            if config[:package][:adaptiveimages].include?(:pixel_density) and config[:package][:adaptiveimages][:pixel_density]
+              contents = "document.cookie='resolution='+Math.max(screen.width,screen.height)+(\"devicePixelRatio\" in window ? \",\"+devicePixelRatio : \",1\")+'; path=/';"
+            else
+              contents = "document.cookie='resolution='+Math.max(screen.width,screen.height)+'; path=/';"
+            end
+            File.open(tmp_js_build_file, "a") { |handle| handle.puts "#{contents};" }
+          end
+          
+        end
+        
+        def reset_package
+          
+          reset_submodule :respond
+          
+        end
+        
+      end
+      
+    end
+    
+  end
+  
+end

--- a/lib/Config.rb
+++ b/lib/Config.rb
@@ -207,6 +207,10 @@ module WebBlocks
     :dir      => 'alphaimagescaling'
   }
   
+  @config[:package][:adaptiveimages] = {
+    :pixel_density  => true
+  }
+  
   @config[:package][:httpclienthints] = {
     :dir      => 'http-client-hints'
   }


### PR DESCRIPTION
This package is useful if `:httpclienthints` is not being used with the fork of Adaptive Images on https://github.com/ebollens/Adaptive-Images. If Adaptive Images accepts the pull request from that fork, then this package will not be needed with it at all in the future because `:httpclienthints` will work just fine on its own.
