### PR TITLE
Fix #492 - Add Structure/Cluster element

### DIFF
--- a/doc/asset/doc/modules.js
+++ b/doc/asset/doc/modules.js
@@ -500,6 +500,22 @@
 			'Base/Structure': {
 				description:'Defines structural classes including a fluid grid, container and constrained content.'
 			},
+            'Base/Structure/Cluster': {
+                description:'Defines a class whereby all direct children (up to six) become equal-width columns that collapse responsively',
+                defines:{
+                    '.cluster':'Parent of clustered elements',
+                    '.cluster.left':'Parent of clustered elements, where uneven collapsed rows will align left',
+                    '.cluster > *':'Clustered elements treated as equal-width columns (up to six allowed)'
+                },
+                uses:[
+                    'structure-cluster-element-gutter',
+                    'structure-cluster-breakpoint-2-columns',
+                    'structure-cluster-breakpoint-3-columns',
+                    'structure-cluster-breakpoint-4-columns',
+                    'structure-cluster-breakpoint-6-columns'
+                ],
+                api:'Base/Structure/Cluster'
+            },
 			'Base/Structure/Grid': {
 				description:'Defines a set of classes that may be used to specify grid layouts for an application whereby, at a particular breakpoint, the row panels collapse to a vertically-oriented set of elements.',
 				defines:{

--- a/doc/asset/doc/vars/sass.js
+++ b/doc/asset/doc/vars/sass.js
@@ -56,6 +56,31 @@
             default_value:'2.5641%',
             type:'percentage'
         },
+        'structure-cluster-element-gutter': {
+            description:'defines spacing between cluster elements',
+            default_value:'2.5641%',
+            type:'percentage'
+        },
+        'structure-cluster-breakpoint-2-columns': {
+            description:'defines breakpoint at which cluster elements may be presented in up to two columns',
+            default_value:'480px',
+            type:'px'
+        },
+        'structure-cluster-breakpoint-3-columns': {
+            description:'defines breakpoint at which cluster elements may be presented in up to three columns',
+            default_value:'640px',
+            type:'px'
+        },
+        'structure-cluster-breakpoint-4-columns': {
+            description:'defines breakpoint at which elements may be presented in up to four columns',
+            default_value:'768px',
+            type:'px'
+        },
+        'structure-cluster-breakpoint-6-columns': {
+            description:'defines breakpoint at which elements may be presented in up to six columns',
+            default_value:'960px',
+            type:'px'
+        },
         'type-font-family': {
             description:'defines the body font family',
             default_value:'"Helvetica Neue", Helvetica, Arial, sans-serif;',

--- a/doc/component/menu/api.ejs
+++ b/doc/component/menu/api.ejs
@@ -7,6 +7,7 @@
     <h1>Base</h1>
     <ul>
         <li><a href="#API/Base/Structure/Container">Container</a></li>
+        <li><a href="#API/Base/Structure/Cluster">Cluster</a></li>
         <li><a href="#API/Base/Structure/Grid">Grid</a></li>
         <li><a href="#API/Base/Color">Color</a></li>
         <li><a href="#API/Base/Block">Block</a></li>

--- a/doc/page/api/base/structure/cluster.ejs
+++ b/doc/page/api/base/structure/cluster.ejs
@@ -1,0 +1,148 @@
+<h2>Structure/Cluster</h2>
+
+<p>This library provides a module for defining a cluster of equal-width responsive content blocks:</p>
+
+<ul class="modules">
+    <li><%= DOC.modules.render('Base/Structure/Cluster') %></li>
+</ul>
+
+<h3>Usage</h3>
+
+<p>The <code>.cluster</code> elements offers an easy way to associate a set of blocks where they will be presented as a set of equal-width columns, collapsing responsively based on the size of the viewport.</p>
+
+<pre class="prettyprint">&lt;div class="cluster"&gt;
+    &lt;div&gt;&lt;!-- First content block --&gt;&lt;/div&gt;
+    &lt;div&gt;&lt;!-- Second content block --&gt;&lt;/div&gt;
+    &lt;div&gt;&lt;!-- Third content block --&gt;&lt;/div&gt;
+&lt;/div&gt;</pre>
+
+<p>By default, if you have an odd number of cluster elements, when they collapse into a multiple rows with unequal numbers of elements, the inequality will be solved by centering the elements. However, the <code>.left</code> class may be applied to the cluster to left align the collapse.</p>
+
+<pre class="prettyprint">&lt;div class="left cluster"&gt;
+    &lt;div&gt;&lt;!-- First content block --&gt;&lt;/div&gt;
+    &lt;div&gt;&lt;!-- Second content block --&gt;&lt;/div&gt;
+    &lt;div&gt;&lt;!-- Third content block --&gt;&lt;/div&gt;
+&lt;/div&gt;</pre>
+
+<p>The <code>.cluster</code> element supports <i>between one and six direct children</i>. If you seek to use more than six direct children, you may nest a cluster within a cluster. If you seek to control responsive behaviors rather than use the default behaviors, use <a href="#API/Base/Structure/Grid">Base/Structure/Grid</a> instead.</p>
+
+
+<h3>Behavior</h3>
+
+<h4>Two Clustered Elements</h4>
+
+<div class="cluster">
+    <div class="primary">&nbsp;</div>
+    <div class="secondary">&nbsp;</div>
+</div>
+
+<pre class="prettyprint" style="margin-top:12px;">&lt;div class="cluster"&gt;
+    &lt;div&gt;&lt;!-- First content block --&gt;&lt;/div&gt;
+    &lt;div&gt;&lt;!-- Second content block --&gt;&lt;/div&gt;
+&lt;/div&gt;</pre>
+
+<h4>Three Clustered Elements</h4>
+
+<div class="cluster">
+    <div class="primary">&nbsp;</div>
+    <div class="secondary">&nbsp;</div>
+    <div class="tertiary">&nbsp;</div>
+</div>
+
+<pre class="prettyprint" style="margin-top:12px;">&lt;div class="cluster"&gt;
+    &lt;div&gt;&lt;!-- First content block --&gt;&lt;/div&gt;
+    &lt;div&gt;&lt;!-- Second content block --&gt;&lt;/div&gt;
+    &lt;div&gt;&lt;!-- Third content block --&gt;&lt;/div&gt;
+&lt;/div&gt;</pre>
+
+<h4>Three Left Clustered Elements</h4>
+
+<div class="left cluster">
+    <div class="primary">&nbsp;</div>
+    <div class="secondary">&nbsp;</div>
+    <div class="tertiary">&nbsp;</div>
+</div>
+
+<pre class="prettyprint" style="margin-top:12px;">&lt;div class="left cluster"&gt;
+    &lt;div&gt;&lt;!-- First content block --&gt;&lt;/div&gt;
+    &lt;div&gt;&lt;!-- Second content block --&gt;&lt;/div&gt;
+    &lt;div&gt;&lt;!-- Third content block --&gt;&lt;/div&gt;
+&lt;/div&gt;</pre>
+
+<h4>Four Clustered Elements</h4>
+
+<div class="cluster">
+    <div class="primary">&nbsp;</div>
+    <div class="secondary">&nbsp;</div>
+    <div class="tertiary">&nbsp;</div>
+    <div class="inverse">&nbsp;</div>
+</div>
+
+<pre class="prettyprint" style="margin-top:12px;">&lt;div class="cluster"&gt;
+    &lt;div&gt;&lt;!-- First content block --&gt;&lt;/div&gt;
+    &lt;div&gt;&lt;!-- Second content block --&gt;&lt;/div&gt;
+    &lt;div&gt;&lt;!-- Third content block --&gt;&lt;/div&gt;
+    &lt;div&gt;&lt;!-- Fourth content block --&gt;&lt;/div&gt;
+&lt;/div&gt;</pre>
+
+<h4>Five Clustered Elements</h4>
+
+<div class="cluster">
+    <div class="primary">&nbsp;</div>
+    <div class="secondary">&nbsp;</div>
+    <div class="tertiary">&nbsp;</div>
+    <div class="inverse">&nbsp;</div>
+    <div class="neutral">&nbsp;</div>
+</div>
+
+<pre class="prettyprint" style="margin-top:12px;">&lt;div class="cluster"&gt;
+    &lt;div&gt;&lt;!-- First content block --&gt;&lt;/div&gt;
+    &lt;div&gt;&lt;!-- Second content block --&gt;&lt;/div&gt;
+    &lt;div&gt;&lt;!-- Third content block --&gt;&lt;/div&gt;
+    &lt;div&gt;&lt;!-- Fourth content block --&gt;&lt;/div&gt;
+    &lt;div&gt;&lt;!-- Fifth content block --&gt;&lt;/div&gt;
+&lt;/div&gt;</pre>
+
+<h4>Five Left Clustered Elements</h4>
+
+<div class="left cluster">
+    <div class="primary">&nbsp;</div>
+    <div class="secondary">&nbsp;</div>
+    <div class="tertiary">&nbsp;</div>
+    <div class="inverse">&nbsp;</div>
+    <div class="neutral">&nbsp;</div>
+</div>
+
+<pre class="prettyprint" style="margin-top:12px;">&lt;div class="left cluster"&gt;
+    &lt;div&gt;&lt;!-- First content block --&gt;&lt;/div&gt;
+    &lt;div&gt;&lt;!-- Second content block --&gt;&lt;/div&gt;
+    &lt;div&gt;&lt;!-- Third content block --&gt;&lt;/div&gt;
+    &lt;div&gt;&lt;!-- Fourth content block --&gt;&lt;/div&gt;
+    &lt;div&gt;&lt;!-- Fifth content block --&gt;&lt;/div&gt;
+&lt;/div&gt;</pre>
+
+<h4>Six Clustered Elements</h4>
+
+<div class="cluster">
+    <div class="primary">&nbsp;</div>
+    <div class="secondary">&nbsp;</div>
+    <div class="tertiary">&nbsp;</div>
+    <div class="inverse">&nbsp;</div>
+    <div class="neutral">&nbsp;</div>
+    <div class="default">&nbsp;</div>
+</div>
+
+<pre class="prettyprint" style="margin-top:12px;">&lt;div class="cluster"&gt;
+    &lt;div&gt;&lt;!-- First content block --&gt;&lt;/div&gt;
+    &lt;div&gt;&lt;!-- Second content block --&gt;&lt;/div&gt;
+    &lt;div&gt;&lt;!-- Third content block --&gt;&lt;/div&gt;
+    &lt;div&gt;&lt;!-- Fourth content block --&gt;&lt;/div&gt;
+    &lt;div&gt;&lt;!-- Fifth content block --&gt;&lt;/div&gt;
+    &lt;div&gt;&lt;!-- Sixth content block --&gt;&lt;/div&gt;
+&lt;/div&gt;</pre>
+
+<h4>Configuration</h4>
+
+<ul class="configuration">
+    <li><%= DOC.modules.render_variables('Base/Structure/Cluster').join('</li><li>') %></li>
+</ul>

--- a/src/core/adapter/base/structure/_cluster.scss
+++ b/src/core/adapter/base/structure/_cluster.scss
@@ -1,0 +1,133 @@
+// these values cannot be overridden
+// provided only to make the math make more sense and for later extensibility
+$structure-cluster-increment:             60;
+$structure-cluster-element-width:         ((100% - ($structure-cluster-increment - 1) * $structure-cluster-element-gutter) / $structure-cluster-increment);
+
+@mixin -base-structure-cluster-element {
+    display: block;
+    float: left;
+    min-height: 1px;
+    box-sizing: border-box;
+    &:not(:first-child) {
+        margin-left: $structure-cluster-element-gutter;
+    }
+}
+
+@function -base-structure-cluster-element-fluid-span-value($columns, $fluidGridColumnWidth, $fluidGridGutterWidth) {
+    @return ($fluidGridColumnWidth * $columns) + ($fluidGridGutterWidth * ($columns - 1));
+}
+
+@mixin -base-structure-cluster-element-fluid-span($columns, $fluidGridColumnWidth, $fluidGridGutterWidth) {
+    width: -base-structure-cluster-element-fluid-span-value($columns, $fluidGridColumnWidth, $fluidGridGutterWidth);
+}
+
+@mixin -base-structure-cluster {
+
+    @extend .float-container;
+
+    &.margin-bottom {
+        margin-bottom: 0;
+        > * {
+            margin-bottom: 0.5em;
+        }
+    }
+
+    img {
+        @extend .constrained;
+    }
+
+    @media (min-width: $structure-cluster-breakpoint-2-columns+1){
+
+        > * {
+            @include -base-structure-cluster-element;
+        }
+
+        > *:first-child:nth-last-child(2),
+        > *:first-child:nth-last-child(2) ~ *,
+        > *:first-child:nth-last-child(3),
+        > *:first-child:nth-last-child(3) ~ *,
+        > *:first-child:nth-last-child(4),
+        > *:first-child:nth-last-child(4) ~ *,
+        > *:first-child:nth-last-child(5),
+        > *:first-child:nth-last-child(5) ~ *,
+        > *:first-child:nth-last-child(6),
+        > *:first-child:nth-last-child(6) ~ * {
+            @include -base-structure-cluster-element-fluid-span($structure-cluster-increment/2, $structure-cluster-element-width, $structure-cluster-element-gutter);
+        }
+
+    }
+
+    @media (min-width: $structure-cluster-breakpoint-2-columns+1) and (max-width: $structure-cluster-breakpoint-3-columns) {
+
+        > *:first-child:nth-last-child(5) ~ *:nth-child(3),
+        > *:first-child:nth-last-child(6) ~ *:nth-child(2n+1),
+        &.left > *:first-child:nth-last-child(3) ~ *:last-child,
+        &.left > *:first-child:nth-last-child(5) ~ *:last-child{
+            margin-left: 0;
+        }
+
+        &:not(.left) > *:first-child:nth-last-child(3) ~ *:last-child,
+        &:not(.left) > *:first-child:nth-last-child(5) ~ *:last-child {
+            margin-left: $structure-cluster-element-gutter + 0.5 * -base-structure-cluster-element-fluid-span-value($structure-cluster-increment/2, $structure-cluster-element-width, $structure-cluster-element-gutter);
+        }
+
+    }
+
+    @media (min-width: $structure-cluster-breakpoint-3-columns+1){
+
+        > *:first-child:nth-last-child(3),
+        > *:first-child:nth-last-child(3) ~ *,
+        > *:first-child:nth-last-child(5),
+        > *:first-child:nth-last-child(5) ~ *,
+        > *:first-child:nth-last-child(6),
+        > *:first-child:nth-last-child(6) ~ * {
+            @include -base-structure-cluster-element-fluid-span($structure-cluster-increment/3, $structure-cluster-element-width, $structure-cluster-element-gutter);
+        }
+
+    }
+
+    @media (min-width: $structure-cluster-breakpoint-2-columns+1) and (max-width: $structure-cluster-breakpoint-4-columns) {
+
+        > *:first-child:nth-last-child(4) ~ *:nth-child(3) {
+            margin-left: 0;
+        }
+
+    }
+
+    @media (min-width: $structure-cluster-breakpoint-4-columns+1){
+
+        > *:first-child:nth-last-child(4),
+        > *:first-child:nth-last-child(4) ~ * {
+            @include -base-structure-cluster-element-fluid-span($structure-cluster-increment/4, $structure-cluster-element-width, $structure-cluster-element-gutter);
+        }
+
+    }
+
+    @media (min-width: $structure-cluster-breakpoint-3-columns+1) and (max-width: $structure-cluster-breakpoint-6-columns){
+
+        &:not(.left) > *:first-child:nth-last-child(5) ~ *:nth-child(4) {
+            margin-left: $structure-cluster-element-gutter + 0.5 * -base-structure-cluster-element-fluid-span-value($structure-cluster-increment/3, $structure-cluster-element-width, $structure-cluster-element-gutter);
+        }
+
+        &.left > *:first-child:nth-last-child(5) ~ *:nth-child(4),
+        > *:first-child:nth-last-child(6) ~ *:nth-child(4) {
+            margin-left: 0;
+        }
+
+    }
+
+    @media (min-width: $structure-cluster-breakpoint-6-columns){
+
+        > *:first-child:nth-last-child(5),
+        > *:first-child:nth-last-child(5) ~ * {
+            @include -base-structure-cluster-element-fluid-span($structure-cluster-increment/5, $structure-cluster-element-width, $structure-cluster-element-gutter);
+        }
+
+        > *:first-child:nth-last-child(6),
+        > *:first-child:nth-last-child(6) ~ * {
+            @include -base-structure-cluster-element-fluid-span($structure-cluster-increment/6, $structure-cluster-element-width, $structure-cluster-element-gutter);
+        }
+
+    }
+
+}

--- a/src/core/adapter/base/structure/_variables.scss
+++ b/src/core/adapter/base/structure/_variables.scss
@@ -8,3 +8,10 @@ $structure-panels:              12 !default;
 $structure-panel-gutter:        2.5641% !default;
 $structure-panel-width:         ((100% - ($structure-panels - 1) * $structure-panel-gutter)
                                 / $structure_panels) !default;
+
+
+$structure-cluster-element-gutter:        $structure-panel-gutter !default;
+$structure-cluster-breakpoint-2-columns: $breakpoint-xsmall !default;
+$structure-cluster-breakpoint-3-columns: $breakpoint-small !default;
+$structure-cluster-breakpoint-4-columns: $breakpoint-medium-small !default;
+$structure-cluster-breakpoint-6-columns: $breakpoint-medium !default;

--- a/src/core/definitions/base/structure/_cluster.scss
+++ b/src/core/definitions/base/structure/_cluster.scss
@@ -1,0 +1,3 @@
+.cluster {
+    @include -base-structure-cluster;
+}


### PR DESCRIPTION
See #492 for discussion. No changes from proposal, except the addition of the `.left` class to go left-preferential on uneven collapse (partially collapsed rows with differing numbers of elements between them).
