### PR TITLE
Fix #424 - Removed screen selectors from base media queries

### DIFF
--- a/src/adapter/bootstrap/base/structure/_container.scss
+++ b/src/adapter/bootstrap/base/structure/_container.scss
@@ -4,8 +4,7 @@
         width: 100%;
         margin: auto;
         @if $structure-container-width-max {
-            @media screen 
-                and (max-width: $structure-container-width-max 
+            @media (max-width: $structure-container-width-max
                                     + $structure-container-width-max 
                                         * (($structure-container-gutter*2)/100%) )
                 and (min-width: $breakpoint-small+1)
@@ -16,15 +15,14 @@
             }
             max-width: $structure-container-width-max;
         } @else {
-            @media screen 
-                and (min-width: $breakpoint-small+1)
+            @media (min-width: $breakpoint-small+1)
             {                                       
                 width: 100% - ($structure-container-gutter*2);
                 margin-left: $structure-container-gutter;
                 margin-right: $structure-container-gutter;
             }
         }
-        @media screen and (max-width: $breakpoint-small) {
+        @media (max-width: $breakpoint-small) {
             width: auto;
             margin-left: ($structure-container-gutter/100%) * $breakpoint-small; 
             margin-right: ($structure-container-gutter/100%) * $breakpoint-small; 

--- a/src/adapter/bootstrap/entity/form/_control.scss
+++ b/src/adapter/bootstrap/entity/form/_control.scss
@@ -47,7 +47,7 @@
 
 @mixin -entity-form-horizontal-control {
     
-    @media screen and (min-width: $breakpoint-small+1) {
+    @media (min-width: $breakpoint-small+1) {
 
         padding-left: $horizontalComponentOffset;
 

--- a/src/core/adapter/base/block/float/_responsive.scss
+++ b/src/core/adapter/base/block/float/_responsive.scss
@@ -1,6 +1,6 @@
 @mixin -base-block-float-left-responsive-xxsmall {
     
-    @media screen and (max-width: $breakpoint-xxsmall) {
+    @media (max-width: $breakpoint-xxsmall) {
         float: left;
     }
     
@@ -8,7 +8,7 @@
 
 @mixin -base-block-float-left-responsive-xsmall {
     
-    @media screen and (max-width: $breakpoint-xsmall) {
+    @media (max-width: $breakpoint-xsmall) {
         float: left;
     }
     
@@ -16,7 +16,7 @@
 
 @mixin -base-block-float-left-responsive-small {
     
-    @media screen and (max-width: $breakpoint-small) {
+    @media (max-width: $breakpoint-small) {
         float: left;
     }
     
@@ -24,7 +24,7 @@
 
 @mixin -base-block-float-left-responsive-medium-small {
     
-    @media screen and (max-width: $breakpoint-medium-small) {
+    @media (max-width: $breakpoint-medium-small) {
         float: left;
     }
     
@@ -32,7 +32,7 @@
 
 @mixin -base-block-float-left-responsive-medium {
     
-    @media screen and (max-width: $breakpoint-medium) {
+    @media (max-width: $breakpoint-medium) {
         float: left;
     }
     
@@ -40,7 +40,7 @@
 
 @mixin -base-block-float-left-responsive-medium-large {
     
-    @media screen and (max-width: $breakpoint-medium-large) {
+    @media (max-width: $breakpoint-medium-large) {
         float: left;
     }
     
@@ -48,7 +48,7 @@
 
 @mixin -base-block-float-left-responsive-large {
     
-    @media screen and (max-width: $breakpoint-large) {
+    @media (max-width: $breakpoint-large) {
         float: left;
     }
     
@@ -56,7 +56,7 @@
 
 @mixin -base-block-float-right-responsive-xxsmall {
     
-    @media screen and (max-width: $breakpoint-xxsmall) {
+    @media (max-width: $breakpoint-xxsmall) {
         float: right;
     }
     
@@ -64,7 +64,7 @@
 
 @mixin -base-block-float-right-responsive-xsmall {
     
-    @media screen and (max-width: $breakpoint-xsmall) {
+    @media (max-width: $breakpoint-xsmall) {
         float: right;
     }
     
@@ -72,7 +72,7 @@
 
 @mixin -base-block-float-right-responsive-small {
     
-    @media screen and (max-width: $breakpoint-small) {
+    @media (max-width: $breakpoint-small) {
         float: right;
     }
     
@@ -80,7 +80,7 @@
 
 @mixin -base-block-float-right-responsive-medium-small {
     
-    @media screen and (max-width: $breakpoint-medium-small) {
+    @media (max-width: $breakpoint-medium-small) {
         float: right;
     }
     
@@ -88,7 +88,7 @@
 
 @mixin -base-block-float-right-responsive-medium {
     
-    @media screen and (max-width: $breakpoint-medium) {
+    @media (max-width: $breakpoint-medium) {
         float: right;
     }
     
@@ -96,7 +96,7 @@
 
 @mixin -base-block-float-right-responsive-medium-large {
     
-    @media screen and (max-width: $breakpoint-medium-large) {
+    @media (max-width: $breakpoint-medium-large) {
         float: right;
     }
     
@@ -104,7 +104,7 @@
 
 @mixin -base-block-float-right-responsive-large {
     
-    @media screen and (max-width: $breakpoint-large) {
+    @media (max-width: $breakpoint-large) {
         float: right;
     }
     

--- a/src/core/adapter/base/block/float/_responsive_above.scss
+++ b/src/core/adapter/base/block/float/_responsive_above.scss
@@ -1,6 +1,6 @@
 @mixin -base-block-float-left-responsive-above-xxsmall {
     
-    @media screen and (min-width: $breakpoint-xxsmall+1) {
+    @media (min-width: $breakpoint-xxsmall+1) {
         float: left;
     }
     
@@ -8,7 +8,7 @@
 
 @mixin -base-block-float-left-responsive-above-xsmall {
     
-    @media screen and (min-width: $breakpoint-xsmall+1) {
+    @media (min-width: $breakpoint-xsmall+1) {
         float: left;
     }
     
@@ -16,7 +16,7 @@
 
 @mixin -base-block-float-left-responsive-above-small {
     
-    @media screen and (min-width: $breakpoint-small+1) {
+    @media (min-width: $breakpoint-small+1) {
         float: left;
     }
     
@@ -24,7 +24,7 @@
 
 @mixin -base-block-float-left-responsive-above-medium-small {
     
-    @media screen and (min-width: $breakpoint-medium-small+1) {
+    @media (min-width: $breakpoint-medium-small+1) {
         float: left;
     }
     
@@ -32,7 +32,7 @@
 
 @mixin -base-block-float-left-responsive-above-medium {
     
-    @media screen and (min-width: $breakpoint-medium+1) {
+    @media (min-width: $breakpoint-medium+1) {
         float: left;
     }
     
@@ -40,7 +40,7 @@
 
 @mixin -base-block-float-left-responsive-above-medium-large {
     
-    @media screen and (min-width: $breakpoint-medium-large+1) {
+    @media (min-width: $breakpoint-medium-large+1) {
         float: left;
     }
     
@@ -48,7 +48,7 @@
 
 @mixin -base-block-float-left-responsive-above-large {
     
-    @media screen and (min-width: $breakpoint-large+1) {
+    @media (min-width: $breakpoint-large+1) {
         float: left;
     }
     
@@ -56,7 +56,7 @@
 
 @mixin -base-block-float-right-responsive-above-xxsmall {
     
-    @media screen and (min-width: $breakpoint-xxsmall+1) {
+    @media (min-width: $breakpoint-xxsmall+1) {
         float: right;
     }
     
@@ -64,7 +64,7 @@
 
 @mixin -base-block-float-right-responsive-above-xsmall {
     
-    @media screen and (min-width: $breakpoint-xsmall+1) {
+    @media (min-width: $breakpoint-xsmall+1) {
         float: right;
     }
     
@@ -72,7 +72,7 @@
 
 @mixin -base-block-float-right-responsive-above-small {
     
-    @media screen and (min-width: $breakpoint-small+1) {
+    @media (min-width: $breakpoint-small+1) {
         float: right;
     }
     
@@ -80,7 +80,7 @@
 
 @mixin -base-block-float-right-responsive-above-medium-small {
     
-    @media screen and (min-width: $breakpoint-medium-small+1) {
+    @media (min-width: $breakpoint-medium-small+1) {
         float: right;
     }
     
@@ -88,7 +88,7 @@
 
 @mixin -base-block-float-right-responsive-above-medium {
     
-    @media screen and (min-width: $breakpoint-medium) {
+    @media (min-width: $breakpoint-medium) {
         float: right;
     }
     
@@ -96,7 +96,7 @@
 
 @mixin -base-block-float-right-responsive-above-medium-large {
     
-    @media screen and (min-width: $breakpoint-medium-large+1) {
+    @media (min-width: $breakpoint-medium-large+1) {
         float: right;
     }
     
@@ -104,7 +104,7 @@
 
 @mixin -base-block-float-right-responsive-above-large {
     
-    @media screen and (min-width: $breakpoint-large+1) {
+    @media (min-width: $breakpoint-large+1) {
         float: right;
     }
     

--- a/src/core/adapter/base/structure/_container.scss
+++ b/src/core/adapter/base/structure/_container.scss
@@ -3,8 +3,7 @@
     width: 100%;
     margin: auto;
     @if $structure-container-width-max {
-        @media screen 
-            and (max-width: $structure-container-width-max 
+        @media (max-width: $structure-container-width-max
                                 + $structure-container-width-max 
                                     * (($structure-container-gutter*2)/100%) )
             and (min-width: $breakpoint-small+1)
@@ -15,15 +14,14 @@
         }
         max-width: $structure-container-width-max;
     } @else {
-        @media screen 
-            and (min-width: $breakpoint-small+1)
+        @media (min-width: $breakpoint-small+1)
         {                                       
             width: 100% - ($structure-container-gutter*2);
             margin-left: $structure-container-gutter;
             margin-right: $structure-container-gutter;
         }
     }
-    @media screen and (max-width: $breakpoint-small) {
+    @media (max-width: $breakpoint-small) {
         width: auto;
         margin-left: ($structure-container-gutter/100%) * $breakpoint-small; 
         margin-right: ($structure-container-gutter/100%) * $breakpoint-small; 

--- a/src/core/adapter/base/type/align/_responsive.scss
+++ b/src/core/adapter/base/type/align/_responsive.scss
@@ -1,6 +1,6 @@
 @mixin -base-type-align-left-responsive-xxsmall {
     
-    @media screen and (max-width: $breakpoint-xxsmall) {
+    @media (max-width: $breakpoint-xxsmall) {
         text-align: left;
     }
     
@@ -8,7 +8,7 @@
 
 @mixin -base-type-align-left-responsive-xsmall {
     
-    @media screen and (max-width: $breakpoint-xsmall) {
+    @media (max-width: $breakpoint-xsmall) {
         text-align: left;
     }
     
@@ -16,7 +16,7 @@
 
 @mixin -base-type-align-left-responsive-small {
     
-    @media screen and (max-width: $breakpoint-small) {
+    @media (max-width: $breakpoint-small) {
         text-align: left;
     }
     
@@ -24,7 +24,7 @@
 
 @mixin -base-type-align-left-responsive-medium-small {
     
-    @media screen and (max-width: $breakpoint-medium-small) {
+    @media (max-width: $breakpoint-medium-small) {
         text-align: left;
     }
     
@@ -32,7 +32,7 @@
 
 @mixin -base-type-align-left-responsive-medium {
     
-    @media screen and (max-width: $breakpoint-medium) {
+    @media (max-width: $breakpoint-medium) {
         text-align: left;
     }
     
@@ -40,7 +40,7 @@
 
 @mixin -base-type-align-left-responsive-medium-large {
     
-    @media screen and (max-width: $breakpoint-medium-large) {
+    @media (max-width: $breakpoint-medium-large) {
         text-align: left;
     }
     
@@ -48,7 +48,7 @@
 
 @mixin -base-type-align-left-responsive-large {
     
-    @media screen and (max-width: $breakpoint-large) {
+    @media (max-width: $breakpoint-large) {
         text-align: left;
     }
     
@@ -56,7 +56,7 @@
 
 @mixin -base-type-align-center-responsive-xxsmall {
     
-    @media screen and (max-width: $breakpoint-xxsmall) {
+    @media (max-width: $breakpoint-xxsmall) {
         text-align: center;
     }
     
@@ -64,7 +64,7 @@
 
 @mixin -base-type-align-center-responsive-xsmall {
     
-    @media screen and (max-width: $breakpoint-xsmall) {
+    @media (max-width: $breakpoint-xsmall) {
         text-align: center;
     }
     
@@ -72,7 +72,7 @@
 
 @mixin -base-type-align-center-responsive-small {
     
-    @media screen and (max-width: $breakpoint-small) {
+    @media (max-width: $breakpoint-small) {
         text-align: center;
     }
     
@@ -80,7 +80,7 @@
 
 @mixin -base-type-align-center-responsive-medium-small {
     
-    @media screen and (max-width: $breakpoint-medium-small) {
+    @media (max-width: $breakpoint-medium-small) {
         text-align: center;
     }
     
@@ -88,7 +88,7 @@
 
 @mixin -base-type-align-center-responsive-medium {
     
-    @media screen and (max-width: $breakpoint-medium) {
+    @media (max-width: $breakpoint-medium) {
         text-align: center;
     }
     
@@ -96,7 +96,7 @@
 
 @mixin -base-type-align-center-responsive-medium-large {
     
-    @media screen and (max-width: $breakpoint-medium-large) {
+    @media (max-width: $breakpoint-medium-large) {
         text-align: center;
     }
     
@@ -104,7 +104,7 @@
 
 @mixin -base-type-align-center-responsive-large {
     
-    @media screen and (max-width: $breakpoint-large) {
+    @media (max-width: $breakpoint-large) {
         text-align: center;
     }
     
@@ -112,7 +112,7 @@
 
 @mixin -base-type-align-right-responsive-xxsmall {
     
-    @media screen and (max-width: $breakpoint-xxsmall) {
+    @media (max-width: $breakpoint-xxsmall) {
         text-align: right;
     }
     
@@ -120,7 +120,7 @@
 
 @mixin -base-type-align-right-responsive-xsmall {
     
-    @media screen and (max-width: $breakpoint-xsmall) {
+    @media (max-width: $breakpoint-xsmall) {
         text-align: right;
     }
     
@@ -128,7 +128,7 @@
 
 @mixin -base-type-align-right-responsive-small {
     
-    @media screen and (max-width: $breakpoint-small) {
+    @media (max-width: $breakpoint-small) {
         text-align: right;
     }
     
@@ -136,7 +136,7 @@
 
 @mixin -base-type-align-right-responsive-medium-small {
     
-    @media screen and (max-width: $breakpoint-medium-small) {
+    @media (max-width: $breakpoint-medium-small) {
         text-align: right;
     }
     
@@ -144,7 +144,7 @@
 
 @mixin -base-type-align-right-responsive-medium {
     
-    @media screen and (max-width: $breakpoint-medium) {
+    @media (max-width: $breakpoint-medium) {
         text-align: right;
     }
     
@@ -152,7 +152,7 @@
 
 @mixin -base-type-align-right-responsive-medium-large {
     
-    @media screen and (max-width: $breakpoint-medium-large) {
+    @media (max-width: $breakpoint-medium-large) {
         text-align: right;
     }
     
@@ -160,7 +160,7 @@
 
 @mixin -base-type-align-right-responsive-large {
     
-    @media screen and (max-width: $breakpoint-large) {
+    @media (max-width: $breakpoint-large) {
         text-align: right;
     }
     
@@ -168,7 +168,7 @@
 
 @mixin -base-type-align-justify-responsive-xxsmall {
     
-    @media screen and (max-width: $breakpoint-xxsmall) {
+    @media (max-width: $breakpoint-xxsmall) {
         text-align: justify;
     }
     
@@ -176,7 +176,7 @@
 
 @mixin -base-type-align-justify-responsive-xsmall {
     
-    @media screen and (max-width: $breakpoint-xsmall) {
+    @media (max-width: $breakpoint-xsmall) {
         text-align: justify;
     }
     
@@ -184,7 +184,7 @@
 
 @mixin -base-type-align-justify-responsive-small {
     
-    @media screen and (max-width: $breakpoint-small) {
+    @media (max-width: $breakpoint-small) {
         text-align: justify;
     }
     
@@ -192,7 +192,7 @@
 
 @mixin -base-type-align-justify-responsive-medium-small {
     
-    @media screen and (max-width: $breakpoint-medium-small) {
+    @media (max-width: $breakpoint-medium-small) {
         text-align: justify;
     }
     
@@ -200,7 +200,7 @@
 
 @mixin -base-type-align-justify-responsive-medium {
     
-    @media screen and (max-width: $breakpoint-medium) {
+    @media (max-width: $breakpoint-medium) {
         text-align: justify;
     }
     
@@ -208,7 +208,7 @@
 
 @mixin -base-type-align-justify-responsive-medium-large {
     
-    @media screen and (max-width: $breakpoint-medium-large) {
+    @media (max-width: $breakpoint-medium-large) {
         text-align: justify;
     }
     
@@ -216,7 +216,7 @@
 
 @mixin -base-type-align-justify-responsive-large {
     
-    @media screen and (max-width: $breakpoint-large) {
+    @media (max-width: $breakpoint-large) {
         text-align: justify;
     }
     

--- a/src/core/adapter/base/type/align/_responsive_above.scss
+++ b/src/core/adapter/base/type/align/_responsive_above.scss
@@ -1,6 +1,6 @@
 @mixin -base-type-align-left-responsive-above-xxsmall {
     
-    @media screen and (min-width: $breakpoint-xxsmall+1) {
+    @media (min-width: $breakpoint-xxsmall+1) {
         text-align: left;
     }
     
@@ -8,7 +8,7 @@
 
 @mixin -base-type-align-left-responsive-above-xsmall {
     
-    @media screen and (min-width: $breakpoint-xsmall+1) {
+    @media (min-width: $breakpoint-xsmall+1) {
         text-align: left;
     }
     
@@ -16,7 +16,7 @@
 
 @mixin -base-type-align-left-responsive-above-small {
     
-    @media screen and (min-width: $breakpoint-small+1) {
+    @media (min-width: $breakpoint-small+1) {
         text-align: left;
     }
     
@@ -24,7 +24,7 @@
 
 @mixin -base-type-align-left-responsive-above-medium-small {
     
-    @media screen and (min-width: $breakpoint-medium-small+1) {
+    @media (min-width: $breakpoint-medium-small+1) {
         text-align: left;
     }
     
@@ -32,7 +32,7 @@
 
 @mixin -base-type-align-left-responsive-above-medium {
     
-    @media screen and (min-width: $breakpoint-medium+1) {
+    @media (min-width: $breakpoint-medium+1) {
         text-align: left;
     }
     
@@ -40,7 +40,7 @@
 
 @mixin -base-type-align-left-responsive-above-medium-large {
     
-    @media screen and (min-width: $breakpoint-medium-large+1) {
+    @media (min-width: $breakpoint-medium-large+1) {
         text-align: left;
     }
     
@@ -48,7 +48,7 @@
 
 @mixin -base-type-align-left-responsive-above-large {
     
-    @media screen and (min-width: $breakpoint-large+1) {
+    @media (min-width: $breakpoint-large+1) {
         text-align: left;
     }
     
@@ -56,7 +56,7 @@
 
 @mixin -base-type-align-center-responsive-above-xxsmall {
     
-    @media screen and (min-width: $breakpoint-xxsmall+1) {
+    @media (min-width: $breakpoint-xxsmall+1) {
         text-align: center;
     }
     
@@ -64,7 +64,7 @@
 
 @mixin -base-type-align-center-responsive-above-xsmall {
     
-    @media screen and (min-width: $breakpoint-xsmall+1) {
+    @media (min-width: $breakpoint-xsmall+1) {
         text-align: center;
     }
     
@@ -72,7 +72,7 @@
 
 @mixin -base-type-align-center-responsive-above-small {
     
-    @media screen and (min-width: $breakpoint-small+1) {
+    @media (min-width: $breakpoint-small+1) {
         text-align: center;
     }
     
@@ -80,7 +80,7 @@
 
 @mixin -base-type-align-center-responsive-above-medium-small {
     
-    @media screen and (min-width: $breakpoint-medium-small+1) {
+    @media (min-width: $breakpoint-medium-small+1) {
         text-align: center;
     }
     
@@ -88,7 +88,7 @@
 
 @mixin -base-type-align-center-responsive-above-medium {
     
-    @media screen and (min-width: $breakpoint-medium) {
+    @media (min-width: $breakpoint-medium) {
         text-align: center;
     }
     
@@ -96,7 +96,7 @@
 
 @mixin -base-type-align-center-responsive-above-medium-large {
     
-    @media screen and (min-width: $breakpoint-medium-large+1) {
+    @media (min-width: $breakpoint-medium-large+1) {
         text-align: center;
     }
     
@@ -104,7 +104,7 @@
 
 @mixin -base-type-align-center-responsive-above-large {
     
-    @media screen and (min-width: $breakpoint-large+1) {
+    @media (min-width: $breakpoint-large+1) {
         text-align: center;
     }
     
@@ -112,7 +112,7 @@
 
 @mixin -base-type-align-right-responsive-above-xxsmall {
     
-    @media screen and (min-width: $breakpoint-xxsmall+1) {
+    @media (min-width: $breakpoint-xxsmall+1) {
         text-align: right;
     }
     
@@ -120,7 +120,7 @@
 
 @mixin -base-type-align-right-responsive-above-xsmall {
     
-    @media screen and (min-width: $breakpoint-xsmall+1) {
+    @media (min-width: $breakpoint-xsmall+1) {
         text-align: right;
     }
     
@@ -128,7 +128,7 @@
 
 @mixin -base-type-align-right-responsive-above-small {
     
-    @media screen and (min-width: $breakpoint-small+1) {
+    @media (min-width: $breakpoint-small+1) {
         text-align: right;
     }
     
@@ -136,7 +136,7 @@
 
 @mixin -base-type-align-right-responsive-above-medium-small {
     
-    @media screen and (min-width: $breakpoint-medium-small+1) {
+    @media (min-width: $breakpoint-medium-small+1) {
         text-align: right;
     }
     
@@ -144,7 +144,7 @@
 
 @mixin -base-type-align-right-responsive-above-medium {
     
-    @media screen and (min-width: $breakpoint-medium+1) {
+    @media (min-width: $breakpoint-medium+1) {
         text-align: right;
     }
     
@@ -152,7 +152,7 @@
 
 @mixin -base-type-align-right-responsive-above-medium-large {
     
-    @media screen and (min-width: $breakpoint-medium-large+1) {
+    @media (min-width: $breakpoint-medium-large+1) {
         text-align: right;
     }
     
@@ -160,7 +160,7 @@
 
 @mixin -base-type-align-right-responsive-above-large {
     
-    @media screen and (min-width: $breakpoint-large+1) {
+    @media (min-width: $breakpoint-large+1) {
         text-align: right;
     }
     
@@ -168,7 +168,7 @@
 
 @mixin -base-type-align-justify-responsive-above-xxsmall {
     
-    @media screen and (min-width: $breakpoint-xxsmall+1) {
+    @media (min-width: $breakpoint-xxsmall+1) {
         text-align: justify;
     }
     
@@ -176,7 +176,7 @@
 
 @mixin -base-type-align-justify-responsive-above-xsmall {
     
-    @media screen and (min-width: $breakpoint-xsmall+1) {
+    @media (min-width: $breakpoint-xsmall+1) {
         text-align: justify;
     }
     
@@ -184,7 +184,7 @@
 
 @mixin -base-type-align-justify-responsive-above-small {
     
-    @media screen and (min-width: $breakpoint-small+1) {
+    @media (min-width: $breakpoint-small+1) {
         text-align: justify;
     }
     
@@ -192,7 +192,7 @@
 
 @mixin -base-type-align-justify-responsive-above-medium-small {
     
-    @media screen and (min-width: $breakpoint-medium-small+1) {
+    @media (min-width: $breakpoint-medium-small+1) {
         text-align: justify;
     }
     
@@ -200,7 +200,7 @@
 
 @mixin -base-type-align-justify-responsive-above-medium {
     
-    @media screen and (min-width: $breakpoint-medium) {
+    @media (min-width: $breakpoint-medium) {
         text-align: justify;
     }
     
@@ -208,7 +208,7 @@
 
 @mixin -base-type-align-justify-responsive-above-medium-large {
     
-    @media screen and (min-width: $breakpoint-medium-large+1) {
+    @media (min-width: $breakpoint-medium-large+1) {
         text-align: justify;
     }
     
@@ -216,7 +216,7 @@
 
 @mixin -base-type-align-justify-responsive-above-large {
     
-    @media screen and (min-width: $breakpoint-large+1) {
+    @media (min-width: $breakpoint-large+1) {
         text-align: justify;
     }
     

--- a/src/core/adapter/base/visibility/media_query/_hide.scss
+++ b/src/core/adapter/base/visibility/media_query/_hide.scss
@@ -1,5 +1,5 @@
 @mixin -base-visibility-hide-media-query {
-    @media screen and (min-width: 0px) {
+    @media (min-width: 0px) {
         display: none;
     }
 }

--- a/src/core/adapter/base/visibility/responsive/_hide.scss
+++ b/src/core/adapter/base/visibility/responsive/_hide.scss
@@ -1,6 +1,6 @@
 @mixin -base-visibility-hide-xxsmall {
     
-    @media screen and (max-width: $breakpoint-xxsmall) {
+    @media (max-width: $breakpoint-xxsmall) {
         display: none;
     }
     
@@ -8,7 +8,7 @@
 
 @mixin -base-visibility-hide-xsmall {
     
-    @media screen and (max-width: $breakpoint-xsmall) {
+    @media (max-width: $breakpoint-xsmall) {
         display: none;
     }
     
@@ -16,7 +16,7 @@
 
 @mixin -base-visibility-hide-small {
     
-    @media screen and (max-width: $breakpoint-small) {
+    @media (max-width: $breakpoint-small) {
         display: none;
     }
     
@@ -24,7 +24,7 @@
 
 @mixin -base-visibility-hide-medium-small {
     
-    @media screen and (max-width: $breakpoint-medium-small) {
+    @media (max-width: $breakpoint-medium-small) {
         display: none;
     }
     
@@ -32,7 +32,7 @@
 
 @mixin -base-visibility-hide-medium {
     
-    @media screen and (max-width: $breakpoint-medium) {
+    @media (max-width: $breakpoint-medium) {
         display: none;
     }
     
@@ -40,7 +40,7 @@
 
 @mixin -base-visibility-hide-medium-large {
     
-    @media screen and (max-width: $breakpoint-medium-large) {
+    @media (max-width: $breakpoint-medium-large) {
         display: none;
     }
     
@@ -48,7 +48,7 @@
 
 @mixin -base-visibility-hide-large {
     
-    @media screen and (max-width: $breakpoint-large) {
+    @media (max-width: $breakpoint-large) {
         display: none;
     }
     

--- a/src/core/adapter/base/visibility/responsive/_hide_above.scss
+++ b/src/core/adapter/base/visibility/responsive/_hide_above.scss
@@ -1,6 +1,6 @@
 @mixin -base-visibility-hide-above-xxsmall {
     
-    @media screen and (min-width: $breakpoint-xxsmall+1) {
+    @media (min-width: $breakpoint-xxsmall+1) {
         display: none;
     }
     
@@ -8,7 +8,7 @@
 
 @mixin -base-visibility-hide-above-xsmall {
     
-    @media screen and (min-width: $breakpoint-xsmall+1) {
+    @media (min-width: $breakpoint-xsmall+1) {
         display: none;
     }
     
@@ -16,7 +16,7 @@
 
 @mixin -base-visibility-hide-above-small {
     
-    @media screen and (min-width: $breakpoint-small+1) {
+    @media (min-width: $breakpoint-small+1) {
         display: none;
     }
     
@@ -24,7 +24,7 @@
 
 @mixin -base-visibility-hide-above-medium-small {
     
-    @media screen and (min-width: $breakpoint-medium-small+1) {
+    @media (min-width: $breakpoint-medium-small+1) {
         display: none;
     }
     
@@ -32,7 +32,7 @@
 
 @mixin -base-visibility-hide-above-medium {
     
-    @media screen and (min-width: $breakpoint-medium+1) {
+    @media (min-width: $breakpoint-medium+1) {
         display: none;
     }
     
@@ -40,7 +40,7 @@
 
 @mixin -base-visibility-hide-above-medium-large {
     
-    @media screen and (min-width: $breakpoint-medium-large+1) {
+    @media (min-width: $breakpoint-medium-large+1) {
         display: none;
     }
     
@@ -48,7 +48,7 @@
 
 @mixin -base-visibility-hide-above-large {
     
-    @media screen and (min-width: $breakpoint-large+1) {
+    @media (min-width: $breakpoint-large+1) {
         display: none;
     }
     

--- a/src/core/adapter/entity/form/_control.scss
+++ b/src/core/adapter/entity/form/_control.scss
@@ -50,7 +50,7 @@
 
 @mixin -entity-form-horizontal-control {
     
-     @media screen and (min-width: $breakpoint-small+1) {
+     @media (min-width: $breakpoint-small+1) {
 
         padding-left: $form-horizontal-offset;
 

--- a/src/core/definitions/base/structure/_grid.scss
+++ b/src/core/definitions/base/structure/_grid.scss
@@ -27,23 +27,23 @@
 
     > [class*="panel-"] {
 
-        @media screen and (min-width: $breakpoint-xxsmall+1) {
+        @media (min-width: $breakpoint-xxsmall+1) {
             @include -base-structure-grid-panel;
         }
 
-        @media screen and (max-width: $breakpoint-xxsmall) {
+        @media (max-width: $breakpoint-xxsmall) {
             @include -base-structure-grid-panel-collapsed;
         }
 
     }
 
     &.right > [class*="panel-"] {
-        @media screen and (min-width: $breakpoint-xxsmall+1) {
+        @media (min-width: $breakpoint-xxsmall+1) {
             @include -base-structure-grid-panel-right;
         }
     }
 
-    @media screen and (min-width: $breakpoint-xxsmall+1) {
+    @media (min-width: $breakpoint-xxsmall+1) {
         @include -base-structure-grid-panels-generate;
     }
     
@@ -57,23 +57,23 @@
 
     > [class*="panel-"] {
 
-        @media screen and (min-width: $breakpoint-xsmall+1) {
+        @media (min-width: $breakpoint-xsmall+1) {
             @include -base-structure-grid-panel;
         }
 
-        @media screen and (max-width: $breakpoint-xsmall) {
+        @media (max-width: $breakpoint-xsmall) {
             @include -base-structure-grid-panel-collapsed;
         }
 
     }
 
     &.right > [class*="panel-"] {
-        @media screen and (min-width: $breakpoint-xsmall+1) {
+        @media (min-width: $breakpoint-xsmall+1) {
             @include -base-structure-grid-panel-right;
         }
     }
 
-    @media screen and (min-width: $breakpoint-xsmall+1) {
+    @media (min-width: $breakpoint-xsmall+1) {
         @include -base-structure-grid-panels-generate;
     }
     
@@ -89,23 +89,23 @@
           
         > [class*="panel-"] {
 
-            @media screen and (min-width: $breakpoint-small+1) {
+            @media (min-width: $breakpoint-small+1) {
                 @include -base-structure-grid-panel;
             }
 
-            @media screen and (max-width: $breakpoint-small) {
+            @media (max-width: $breakpoint-small) {
                 @include -base-structure-grid-panel-collapsed;
             }
 
         }
         
         &.right > [class*="panel-"] {
-            @media screen and (min-width: $breakpoint-small+1) {
+            @media (min-width: $breakpoint-small+1) {
                 @include -base-structure-grid-panel-right;
             }
         }
         
-        @media screen and (min-width: $breakpoint-small+1) {
+        @media (min-width: $breakpoint-small+1) {
             @include -base-structure-grid-panels-generate;
         }
     
@@ -121,23 +121,23 @@
 
     > [class*="panel-"] {
 
-        @media screen and (min-width: $breakpoint-medium-small+1) {
+        @media (min-width: $breakpoint-medium-small+1) {
             @include -base-structure-grid-panel;
         }
 
-        @media screen and (max-width: $breakpoint-medium-small) {
+        @media (max-width: $breakpoint-medium-small) {
             @include -base-structure-grid-panel-collapsed;
         }
 
     }
 
     &.right > [class*="panel-"] {
-        @media screen and (min-width: $breakpoint-medium-small+1) {
+        @media (min-width: $breakpoint-medium-small+1) {
             @include -base-structure-grid-panel-right;
         }
     }
 
-    @media screen and (min-width: $breakpoint-medium-small+1) {
+    @media (min-width: $breakpoint-medium-small+1) {
         @include -base-structure-grid-panels-generate;
     }
 
@@ -151,23 +151,23 @@
 
     > [class*="panel-"] {
 
-        @media screen and (min-width: $breakpoint-medium+1) {
+        @media (min-width: $breakpoint-medium+1) {
             @include -base-structure-grid-panel;
         }
 
-        @media screen and (max-width: $breakpoint-medium) {
+        @media (max-width: $breakpoint-medium) {
             @include -base-structure-grid-panel-collapsed;
         }
 
     }
 
     &.right > [class*="panel-"] {
-        @media screen and (min-width: $breakpoint-medium+1) {
+        @media (min-width: $breakpoint-medium+1) {
             @include -base-structure-grid-panel-right;
         }
     }
 
-    @media screen and (min-width: $breakpoint-medium+1) {
+    @media (min-width: $breakpoint-medium+1) {
         @include -base-structure-grid-panels-generate;
     }
     
@@ -181,23 +181,23 @@
 
     > [class*="panel-"] {
 
-        @media screen and (min-width: $breakpoint-medium-large+1) {
+        @media (min-width: $breakpoint-medium-large+1) {
             @include -base-structure-grid-panel;
         }
 
-        @media screen and (max-width: $breakpoint-medium-large) {
+        @media (max-width: $breakpoint-medium-large) {
             @include -base-structure-grid-panel-collapsed;
         }
 
     }
 
     &.right > [class*="panel-"] {
-        @media screen and (min-width: $breakpoint-medium-large+1) {
+        @media (min-width: $breakpoint-medium-large+1) {
             @include -base-structure-grid-panel-right;
         }
     }
 
-    @media screen and (min-width: $breakpoint-medium-large+1) {
+    @media (min-width: $breakpoint-medium-large+1) {
         @include -base-structure-grid-panels-generate;
     }
     
@@ -211,23 +211,23 @@
 
     > [class*="panel-"] {
 
-        @media screen and (min-width: $breakpoint-large+1) {
+        @media (min-width: $breakpoint-large+1) {
             @include -base-structure-grid-panel;
         }
 
-        @media screen and (max-width: $breakpoint-large) {
+        @media (max-width: $breakpoint-large) {
             @include -base-structure-grid-panel-collapsed;
         }
 
     }
 
     &.right > [class*="panel-"] {
-        @media screen and (min-width: $breakpoint-large+1) {
+        @media (min-width: $breakpoint-large+1) {
             @include -base-structure-grid-panel-right;
         }
     }
 
-    @media screen and (min-width: $breakpoint-large+1) {
+    @media (min-width: $breakpoint-large+1) {
         @include -base-structure-grid-panels-generate;
     }
     


### PR DESCRIPTION
This fix resolves the fact that media query rules to present have included `screen` in their selector. Now, grids and other such presentational components will render print just as they do screen.
