### PR TITLE
Fix #390 - Add [:src][:packages] and deprecate [:build][:packages]

### DIFF
--- a/Rakefile-config.rb
+++ b/Rakefile-config.rb
@@ -27,7 +27,7 @@
 #     
 #   Packages 
 #   
-#     WebBlocks.config[:build][:packages] = [:jquery, :modernizr, :respond, :selectivizr, :efx]
+#     WebBlocks.config[:src][:packages] = [:jquery, :matchMedia, :respond, :selectivizr, :modernizr, :picturefill, :efx]
 #
 # This file may also reside elsewhere in your filesystem, in which case Rake 
 # should be passed a command-line property on invocation:

--- a/doc/component/builder/compiler-config.ejs
+++ b/doc/component/builder/compiler-config.ejs
@@ -360,7 +360,7 @@
 					return;
 				arr.push(this)
 			})
-			output.push('WebBlocks.config[:build][:packages] = ['+arr.join(',')+']');
+			output.push('WebBlocks.config[:src][:packages] = ['+arr.join(',')+']');
 		}
         
         if(options.build.debug){

--- a/doc/page/api/package/adaptiveimages.ejs
+++ b/doc/page/api/package/adaptiveimages.ejs
@@ -6,7 +6,7 @@
 
 <p>If using Adaptive Images directly, the Javascript component that writes the cookie may be added as:</p>
 
-<pre class="prettyprint">WebBlocks.config[:build][:packages] << :adaptiveimages</pre>
+<pre class="prettyprint">WebBlocks.config[:src][:packages] << :adaptiveimages</pre>
 
 <p>By default, this package will compress images at higher quality when the device in question has a high pixel density screen; however, this comes at the cost of larger images for high pixel density screens, and it may be disabled as:</p>
 
@@ -26,6 +26,6 @@
 
 <p>Using this fork, the <code>:adaptiveimages</code> package <em>is not</em> needed. Instead, simply make sure that the HTTP Client Hints package is included:</p>
 
-<pre class='prettyprint'>WebBlocks.config[:build][:packages] << :httpclienthints</pre>
+<pre class='prettyprint'>WebBlocks.config[:src][:packages] << :httpclienthints</pre>
 
 <p>This package is not included by default.</p>

--- a/doc/page/api/package/fastclick.ejs
+++ b/doc/page/api/package/fastclick.ejs
@@ -6,7 +6,7 @@
 
 <p>To include this package, add the following to <code>Rakefile-config.rb</code>:</p>
 
-<pre class="prettyprint">WebBlocks.config[:build][:packages] << :fastclick</pre>
+<pre class="prettyprint">WebBlocks.config[:src][:packages] << :fastclick</pre>
 
 <p>This package is not included by default.</p>
 

--- a/doc/page/api/package/fitvids.ejs
+++ b/doc/page/api/package/fitvids.ejs
@@ -6,7 +6,7 @@
 
 <p>To include this package, add the following to <code>Rakefile-config.rb</code>:</p>
 
-<pre class="prettyprint">WebBlocks.config[:build][:packages] << :fitvids</pre>
+<pre class="prettyprint">WebBlocks.config[:src][:packages] << :fitvids</pre>
 
 <p>This package is not included by default.</p>
 

--- a/doc/page/api/package/httpclienthints.ejs
+++ b/doc/page/api/package/httpclienthints.ejs
@@ -12,7 +12,7 @@
 
 <p>To include this package, add the following to <code>Rakefile-config.rb</code>:</p>
 
-<pre class="prettyprint">WebBlocks.config[:build][:packages] << :httpclienthints</pre>
+<pre class="prettyprint">WebBlocks.config[:src][:packages] << :httpclienthints</pre>
 
 <p>This package is not included by default.</p>
 

--- a/doc/page/api/package/ie7imagescaling.ejs
+++ b/doc/page/api/package/ie7imagescaling.ejs
@@ -23,6 +23,6 @@
 
 <p>To enable AlphaImageLoader scaling for all images, add the following to <code>Rakefile-config.rb</code>:</p>
 
-<pre class="prettyprint">WebBlocks.config[:build][:packages] << :alphaimagescaling</pre>
+<pre class="prettyprint">WebBlocks.config[:src][:packages] << :alphaimagescaling</pre>
 
 <p>This package is not included by default.</p>

--- a/doc/page/api/package/matchmedia.ejs
+++ b/doc/page/api/package/matchmedia.ejs
@@ -22,8 +22,8 @@ if (matchMedia('all and (orientation:landscape)').matches) {
 
 <p>To disable this package, add a line removing it within <code>Rakefile-config.rb</code>:</p>
 
-<pre class="prettyprint">WebBlocks.config[:build][:packages].remove :matchMedia</pre>
+<pre class="prettyprint">WebBlocks.config[:src][:packages].remove :matchMedia</pre>
 
 <p>If you are explicitly defining packages in <code>Rakefile-config.rb</code>, add the <code>:matchMedia</code> package as follows:</p>
 
-<pre class="prettyprint">WebBlocks.config[:build][:packages] << :matchMedia</pre>
+<pre class="prettyprint">WebBlocks.config[:src][:packages] << :matchMedia</pre>

--- a/doc/page/api/package/picturefill.ejs
+++ b/doc/page/api/package/picturefill.ejs
@@ -18,8 +18,8 @@
 
 <p>To disable this package, add a line removing it within <code>Rakefile-config.rb</code>:</p>
 
-<pre class="prettyprint">WebBlocks.config[:build][:packages].remove :picturefill</pre>
+<pre class="prettyprint">WebBlocks.config[:src][:packages].remove :picturefill</pre>
 
 <p>If you are explicitly defining packages in <code>Rakefile-config.rb</code>, add the <code>:matchMedia</code> package as follows:</p>
 
-<pre class="prettyprint">WebBlocks.config[:build][:packages] << :picturefill</pre>
+<pre class="prettyprint">WebBlocks.config[:src][:packages] << :picturefill</pre>

--- a/doc/page/api/package/remunit.ejs
+++ b/doc/page/api/package/remunit.ejs
@@ -6,6 +6,6 @@
 
 <p>To include this package, add the following to <code>Rakefile-config.rb</code>:</p>
 
-<pre class="prettyprint">WebBlocks.config[:build][:packages] << :remunit</pre>
+<pre class="prettyprint">WebBlocks.config[:src][:packages] << :remunit</pre>
 
 <p>This package is not included by default.</p>

--- a/doc/page/api/package/srcset.ejs
+++ b/doc/page/api/package/srcset.ejs
@@ -12,6 +12,6 @@
 
 <p>To include this package, add the following to <code>Rakefile-config.rb</code>:</p>
 
-<pre class="prettyprint">WebBlocks.config[:build][:packages] << :srcset</pre>
+<pre class="prettyprint">WebBlocks.config[:src][:packages] << :srcset</pre>
 
 <p>This package is not included by default.</p>

--- a/doc/page/configuration/compiler/components.ejs
+++ b/doc/page/configuration/compiler/components.ejs
@@ -67,7 +67,7 @@ WebBlocks.config[:src][:modules] << 'entity/form'</pre>
 
 <p>By default, several packages are compiled with WebBlocks:</p>
 
-<pre class="prettyprint">WebBlocks.config[:build][:packages] = [
+<pre class="prettyprint">WebBlocks.config[:src][:packages] = [
     :jquery,
     :modernizr,
     :respond,
@@ -77,17 +77,17 @@ WebBlocks.config[:src][:modules] << 'entity/form'</pre>
 
 <p>A package can be removed as:</p>
 
-<pre class="prettyprint">WebBlocks.config[:build][:packages].delete :jquery</pre>
+<pre class="prettyprint">WebBlocks.config[:src][:packages].delete :jquery</pre>
 
 <p>This is useful, for example, if jQuery is already being included by another <code>script</code> tag within the application where WebBlocks will be used.</p>
 
 <p>An additional package can be added as:</p>
 
-<pre class="prettyprint">WebBlocks.config[:build][:packages] << :lettering</pre>
+<pre class="prettyprint">WebBlocks.config[:src][:packages] << :lettering</pre>
 
 <p>The package set compiled with WebBlocks can also be completely redefined such as:</p>
 
-<pre class="prettyprint">WebBlocks.config[:build][:packages] = []
-WebBlocks.config[:build][:packages] << :modernizr
-WebBlocks.config[:build][:packages] << :respond
-WebBlocks.config[:build][:packages] << :selectivizr</pre>
+<pre class="prettyprint">WebBlocks.config[:src][:packages] = []
+WebBlocks.config[:src][:packages] << :modernizr
+WebBlocks.config[:src][:packages] << :respond
+WebBlocks.config[:src][:packages] << :selectivizr</pre>

--- a/doc/page/core/architecture/terminology.ejs
+++ b/doc/page/core/architecture/terminology.ejs
@@ -28,10 +28,10 @@
 
 <p>When building WebBlocks via <code>rake</code>, one may modify the packages to be included by modifying <code>Rakefile-config.rb</code>. For example, to only include Modernizr, Respond.js and Selectivizr, the build configuration could be set as:</p>
 
-<pre class="prettyprint">WebBlocks.config[:build][:packages] = []
-WebBlocks.config[:build][:packages] << :modernizr
-WebBlocks.config[:build][:packages] << :respond
-WebBlocks.config[:build][:packages] << :selectivizr</pre>
+<pre class="prettyprint">WebBlocks.config[:src][:packages] = []
+WebBlocks.config[:src][:packages] << :modernizr
+WebBlocks.config[:src][:packages] << :respond
+WebBlocks.config[:src][:packages] << :selectivizr</pre>
 
 <h3>Module</h3>
 

--- a/lib/Build/Manager.rb
+++ b/lib/Build/Manager.rb
@@ -19,7 +19,7 @@ module WebBlocks
       
       def attach_packages
         
-        config[:build][:packages].each do |package|
+        (config[:src][:packages] | config[:build][:packages]).each do |package|
           
           path = ::WebBlocks::Path.from_root_to "lib/Build/Package/#{package.to_s.downcase.capitalize}.rb"
           

--- a/lib/Build/Module.rb
+++ b/lib/Build/Module.rb
@@ -403,7 +403,7 @@ module WebBlocks
             lines.each do |line|
               line.gsub! /^\/\/\!\s*requires_package\s*/, ''
               line.split(/\s/).each do |dependency|
-                log.warning "Package #{dependency} required and must be included external to WebBlocks" unless config[:build][:packages].include? dependency.to_sym
+                log.warning "Package #{dependency} required and must be included external to WebBlocks" unless (config[:src][:packages] | config[:build][:packages]).include? dependency.to_sym
               end
             end
           end

--- a/lib/Build/Package/Fitvids.rb
+++ b/lib/Build/Package/Fitvids.rb
@@ -27,9 +27,11 @@ module WebBlocks
         def preprocess_js
           
           preprocess_submodule :fitvids
+
+          packages = (config[:src][:packages] | config[:build][:packages])
           
-          if config[:build][:packages].include? :jquery
-            log.failure "Package: FitVids", "Package jquery must be loaded before fitvids" if config[:build][:packages].index(:jquery) > config[:build][:packages].index(:fitvids)
+          if packages.include? :jquery
+            log.failure "Package: FitVids", "Package jquery must be loaded before fitvids" if packages.index(:jquery) > packages.index(:fitvids)
           else
             log.warning "Package: FitVids", "Package jquery required but not included -- ensure it is loaded externally"
           end

--- a/lib/Config.rb
+++ b/lib/Config.rb
@@ -95,17 +95,9 @@ module WebBlocks
   @config[:build][:img] = {
     :dir      => 'img'
   }
-  
-  @config[:build][:packages] = [
-    :jquery,
-    :matchMedia,
-    :respond,
-    :selectivizr,
-    :modernizr,
-    :picturefill,
-    :efx,
-  # :opticss, # experimental: use with caution
-  ]
+
+  # DEPRECATED -- USE config[:src][:packages] instead
+  @config[:build][:packages] = []
   
   # src configuration
   
@@ -159,6 +151,16 @@ module WebBlocks
         :dir => 'adapter'
       }
     },
+
+    :packages => [
+      :jquery,
+      :matchMedia,
+      :respond,
+      :selectivizr,
+      :modernizr,
+      :picturefill,
+      :efx,
+    ],
     
     :adapter  => 'bootstrap',         # name of directory in /src/adapter or false
     
@@ -166,7 +168,7 @@ module WebBlocks
                   'base',             # array of directories in /src/core/definitions
                   'compatibility',    # or false if no modules to include
                   'entity',           # or :all to include all modules
-                  ],          
+                  ],
                                       
     :extensions => []                 # array of additional directories in /src
                                       # or false if no additional directories to include


### PR DESCRIPTION
To ensure backwards compatibility, we use a unary merge:

``` ruby
WebBlocks.config[:src][:packages] | WebBlocks.config[:build][:packages]
```

The only strangeness that will occur here is that .delete on `WebBlocks.config[:build][:packages]` will no longer work. **This needs to be noted in the release notes**
